### PR TITLE
no fullscreen button in fad

### DIFF
--- a/index.js
+++ b/index.js
@@ -4087,7 +4087,7 @@ class LyricsContainer extends react.Component {
           )
         ),
         // Fullscreen toggle button
-        react.createElement(
+        (() => !document.getElementById("fad-lyrics-plus-container"))() && react.createElement(
           Spicetify.ReactComponent.TooltipWrapper,
           {
             label: I18n.t("menu.fullscreen"),


### PR DESCRIPTION
FAD를 사용할시 전체화면 버튼이 보이지 않게 합니다.

## 일반
<img width="1910" height="1176" alt="CleanShot 2025-11-26 at 15 45 45@2x" src="https://github.com/user-attachments/assets/6d319a6b-68c7-4446-a8ac-160f274c97fb" />
## FAD
<img width="1338" height="1396" alt="CleanShot 2025-11-26 at 15 45 51@2x" src="https://github.com/user-attachments/assets/8584f3b7-aa69-45ca-b3a6-43382ad72628" />
## 풀스크린
<img width="1516" height="1318" alt="CleanShot 2025-11-26 at 15 46 06@2x" src="https://github.com/user-attachments/assets/eb08b159-fd2d-4b3a-be0b-0b29f5c046e4" />
