### PR TITLE
Fix: Ensure TMI generates in system language by handling region codes…

### DIFF
--- a/Addon_AI_ChatGPT.js
+++ b/Addon_AI_ChatGPT.js
@@ -211,7 +211,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -284,21 +286,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/Addon_AI_Claude.js
+++ b/Addon_AI_Claude.js
@@ -146,7 +146,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -219,21 +221,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/Addon_AI_Gemini.js
+++ b/Addon_AI_Gemini.js
@@ -188,7 +188,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -268,16 +270,21 @@ OUTPUT (${lineCount} lines):`;
 
         return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output MUST be valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "A 2-3 sentence description of the song and its significance",
+    "description": "2-3 sentence description in ${langInfo.native}",
     "trivia": [
-      "Interesting fact 1 about the song",
-      "Interesting fact 2 about the song",
-      "Interesting fact 3 about the song"
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
     ],
     "sources": {
       "verified": [],

--- a/Addon_AI_Groq.js
+++ b/Addon_AI_Groq.js
@@ -141,7 +141,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -214,21 +216,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/Addon_AI_OpenRouter.js
+++ b/Addon_AI_OpenRouter.js
@@ -141,7 +141,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -214,21 +216,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/Addon_AI_Perplexity.js
+++ b/Addon_AI_Perplexity.js
@@ -143,7 +143,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -216,21 +218,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/Addon_AI_Pollinations.js
+++ b/Addon_AI_Pollinations.js
@@ -150,7 +150,9 @@
     }
 
     function getLangInfo(lang) {
-        return LANGUAGE_DATA[lang] || LANGUAGE_DATA['en'];
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
     }
 
     // ============================================
@@ -223,21 +225,44 @@ OUTPUT (${lineCount} lines):`;
     function buildTMIPrompt(title, artist, lang) {
         const langInfo = getLangInfo(lang);
 
-        return `Generate interesting facts about the song "${title}" by "${artist}".
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
 
-**Output language**: ${langInfo.name} (${langInfo.native})
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+Even if the song is English, the description and trivia MUST be written in ${langInfo.native}.
 
-**Output valid JSON**:
+**Output conditions**:
+1. Language: STRICTLY ${langInfo.name} (${langInfo.native})
+2. Format: JSON
+
+**Output JSON Structure**:
 {
   "track": {
-    "description": "2-3 sentence description",
-    "trivia": ["fact 1", "fact 2", "fact 3"],
-    "sources": {"verified": [], "related": [], "other": []},
-    "reliability": {"confidence": "medium", "has_verified_sources": false, "verified_source_count": 0, "related_source_count": 0, "total_source_count": 0}
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
   }
 }
 
-Write in ${langInfo.native}. Include 3-5 interesting facts.`;
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Be accurate - if you're not sure about a fact, mark confidence as "low"
+4. Do NOT use markdown code blocks`;
     }
 
     // ============================================

--- a/SongInfoTicker.js
+++ b/SongInfoTicker.js
@@ -24,8 +24,8 @@ const SongInfoTMI = (() => {
     // Fetch song info from backend (via LyricsService)
     async function fetchSongInfo(trackId, regenerate = false) {
         // SongDataService와 동일한 언어 설정 사용 (translation-language 우선, language 폴백)
-        const lang = CONFIG.visual["translation-language"] || CONFIG.visual["language"] || 'en';
-        const cacheKey = `${trackId}:${lang}`;
+        const lang = CONFIG.visual["translation-language"] || CONFIG.visual["language"];
+        const cacheKey = `${trackId}:${lang || 'auto'}`;
 
         // Check memory cache first (skip if regenerating)
         if (!regenerate && tmiCache.has(cacheKey)) {
@@ -54,7 +54,8 @@ const SongInfoTMI = (() => {
                 trackId,
                 title,
                 artist,
-                lang
+                lang,
+                ignoreCache: regenerate
             });
 
             if (result) {


### PR DESCRIPTION
This PR resolves an issue where TMI content would default to English even when the system language was set to Korean, Japanese, etc.
**Changes:**
- Updated `LyricsService.js` (SongInfoTicker.js) to properly detect system language instead of hard-defaulting to English.
- Updated ALL AI providers (`Addon_AI_*.js`) to handle locale codes correctly (e.g., matching `ko-KR` to `ko`).
- Updated prompts to strictly enforce the target language output for TMI/Trivia.