### PR TITLE
feat: Add multi-provider AI support for TMI feature

### DIFF
--- a/FullscreenOverlay.js
+++ b/FullscreenOverlay.js
@@ -976,10 +976,10 @@ const FullscreenOverlay = (() => {
         const tvModeEnabled = CONFIG?.visual?.["fullscreen-tv-mode"] === true;
         const tvAlbumSize = Number(CONFIG?.visual?.["fullscreen-tv-album-size"]) || 140;
         const trimTitleEnabled = CONFIG?.visual?.["fullscreen-trim-title"] === true;
-        
+
         // Normal mode settings
         const normalShowAlbumName = CONFIG?.visual?.["fullscreen-show-album-name"] !== false;
-        
+
         // TV Mode specific settings
         const tvShowAlbumName = CONFIG?.visual?.["fullscreen-tv-show-album-name"] !== false;
         const tvShowControls = CONFIG?.visual?.["fullscreen-tv-show-controls"] !== false;
@@ -1023,23 +1023,10 @@ const FullscreenOverlay = (() => {
                 return;
             }
 
-            const apiKey = CONFIG.visual?.["gemini-api-key"];
-            if (!apiKey || (apiKey.startsWith('[') && apiKey.includes('""') && apiKey.length < 10)) { // Simple validation
-                // If apiKey is empty list or empty string
-            }
-            // Actually original check was simple !apiKey
-            // If I change to ConfigKeyList, apiKey might be '[""]' string.
-            // !'[""]' is false. So it passes.
-            // I should improve check.
-            let hasKey = !!apiKey;
-            if (apiKey && apiKey.trim().startsWith('[')) {
-                try {
-                    const parsed = JSON.parse(apiKey);
-                    hasKey = parsed.some(k => k && k.trim().length > 0);
-                } catch (e) { hasKey = false; }
-            }
+            // Check if any AI provider is available for TMI generation
+            const hasAIProvider = window.AIAddonManager?.getEnabledProvidersFor('tmi')?.length > 0;
 
-            if (!hasKey) {
+            if (!hasAIProvider) {
                 Toast.error(I18n.t("tmi.requireKey"));
                 return;
             }
@@ -1179,7 +1166,7 @@ const FullscreenOverlay = (() => {
                     },
                         react.createElement("div", { className: "album-tmi-hint-content" },
                             react.createElement("span", { className: "album-tmi-text" },
-                                CONFIG.visual?.["gemini-api-key"]
+                                (window.AIAddonManager?.getEnabledProvidersFor('tmi')?.length > 0)
                                     ? I18n.t("tmi.viewInfo")
                                     : I18n.t("tmi.requireKey")
                             )
@@ -1264,11 +1251,11 @@ const FullscreenOverlay = (() => {
                     )
                 ),
                 // TV Mode Controls & Progress (right side)
-                (tvShowControls || tvShowProgress) && react.createElement("div", { 
+                (tvShowControls || tvShowProgress) && react.createElement("div", {
                     className: "fullscreen-tv-controls-wrapper"
                 },
                     // TV Mode Controls
-                    tvShowControls && react.createElement("div", { 
+                    tvShowControls && react.createElement("div", {
                         className: "fullscreen-tv-controls"
                     },
                         // Previous button
@@ -1276,10 +1263,10 @@ const FullscreenOverlay = (() => {
                             className: "fullscreen-tv-control-btn",
                             onClick: () => Spicetify.Player.back(),
                             title: "Previous"
-                        }, 
+                        },
                             react.createElement("svg", {
                                 width: "24", height: "24", viewBox: "0 0 16 16", fill: "currentColor"
-                            }, 
+                            },
                                 react.createElement("path", { d: "M3.3 1a.7.7 0 0 1 .7.7v5.15l9.95-5.744a.7.7 0 0 1 1.05.606v12.575a.7.7 0 0 1-1.05.607L4 9.149V14.3a.7.7 0 0 1-.7.7H1.7a.7.7 0 0 1-.7-.7V1.7a.7.7 0 0 1 .7-.7h1.6z" })
                             )
                         ),
@@ -1314,11 +1301,11 @@ const FullscreenOverlay = (() => {
                         )
                     ),
                     // TV Mode Progress bar
-                    tvShowProgress && react.createElement("div", { 
+                    tvShowProgress && react.createElement("div", {
                         className: "fullscreen-tv-progress"
                     },
                         react.createElement("span", { className: "fullscreen-tv-time current" }, formatTime(position)),
-                        react.createElement("div", { 
+                        react.createElement("div", {
                             className: "fullscreen-tv-progress-bar",
                             onClick: (e) => {
                                 const rect = e.currentTarget.getBoundingClientRect();
@@ -1439,12 +1426,12 @@ const FullscreenOverlay = (() => {
                             },
                                 react.createElement("div", { className: "album-tmi-hint-content" },
                                     react.createElement("span", { className: "album-tmi-text" },
-                                        CONFIG.visual?.["gemini-api-key"]
+                                        (window.AIAddonManager?.getEnabledProvidersFor('tmi')?.length > 0)
                                             ? I18n.t("tmi.viewInfo")
                                             : I18n.t("tmi.requireKey")
                                     ),
-                                    CONFIG.visual?.["gemini-api-key"] && react.createElement("span", { 
-                                        className: "album-tmi-disclaimer" 
+                                    (window.AIAddonManager?.getEnabledProvidersFor('tmi')?.length > 0) && react.createElement("span", {
+                                        className: "album-tmi-disclaimer"
                                     }, I18n.t("tmi.disclaimer"))
                                 )
                             )

--- a/LyricsService.js
+++ b/LyricsService.js
@@ -1849,26 +1849,28 @@
 
         /**
          * TMI(Trivia) 가져오기
-         * @param {Object} info - 트랙 정보 { trackId, title, artist, lang }
+         * @param {Object} info - 트랙 정보 { trackId, title, artist, lang, ignoreCache }
          * @returns {Promise<Object|null>}
          */
         async getTMI(info) {
-            const { trackId, title, artist, lang } = info;
+            const { trackId, title, artist, lang, ignoreCache } = info;
             if (!trackId) return null;
 
             const userLang = lang || Spicetify.Locale?.getLocale()?.split('-')[0] || 'en';
 
             try {
-                // 1. 로컬 캐시 확인
-                const cached = await LyricsCache.getTMI(trackId, userLang);
-                if (cached) {
-                    console.log(`[LyricsService] getTMI: Using cached data for ${trackId}`);
-                    return cached;
+                // 1. 로컬 캐시 확인 (ignoreCache가 true면 스킵)
+                if (!ignoreCache) {
+                    const cached = await LyricsCache.getTMI(trackId, userLang);
+                    if (cached) {
+                        console.log(`[LyricsService] getTMI: Using cached data for ${trackId}`);
+                        return cached;
+                    }
                 }
 
                 // 2. Addon_AI 요청
                 if (window.AIAddonManager) {
-                    console.log(`[LyricsService] getTMI: Requesting from AIAddonManager`);
+                    console.log(`[LyricsService] getTMI: Requesting from AIAddonManager${ignoreCache ? ' (ignoring cache)' : ''}`);
                     const result = await window.AIAddonManager.generateTMI({
                         trackId,
                         title,

--- a/langs/LangAr.js
+++ b/langs/LangAr.js
@@ -1596,7 +1596,7 @@ window.LANG_AR = {
     "getApiKeyDesc": "الحصول على مفتاح Gemini API",
     "getApiKeyInfo": "يستخدم لجلب معلومات TMI. يمكن الحصول عليه مجانًا من Google AI Studio.",
     "viewInfo": "اضغط للتحقق من معلومات متنوعة حول هذه الأغنية",
-    "requireKey": "يتطلب إعداد مفتاح Gemini API في الإعدادات",
+    "requireKey": "يتطلب إعداد موفر الذكاء الاصطناعي في الإعدادات",
     "settingTitle": "مفتاح Gemini API",
     "settingDesc": "مطلوب لجلب TMI/معلومات الأغنية.",
     "title": "TMI (معلومات إضافية)",

--- a/langs/LangBn.js
+++ b/langs/LangBn.js
@@ -1597,7 +1597,7 @@ window.LANG_BN = {
     "getApiKeyDesc": "Gemini API কি সংগ্রহ করুন",
     "getApiKeyInfo": "TMI লোড করতে এটি ব্যবহার করা হয়। Google AI Studio থেকে বিনামূল্যে পাওয়া যাবে।",
     "viewInfo": "এই গান সম্পর্কে বিভিন্ন তথ্য জানতে ক্লিক করুন",
-    "requireKey": "সেটিংসে Gemini API কি সেট করা প্রয়োজন",
+    "requireKey": "সেটিংসে AI প্রদানকারী কনফিগার করা প্রয়োজন",
     "settingTitle": "Gemini API কি",
     "settingDesc": "গানের TMI/তথ্য লোড করার জন্য প্রয়োজন।",
     "title": "TMI",

--- a/langs/LangDe.js
+++ b/langs/LangDe.js
@@ -1596,7 +1596,7 @@ window.LANG_DE = {
     "getApiKeyDesc": "Gemini API-Schlüssel holen",
     "getApiKeyInfo": "Wird für TMI-Infos benötigt. Kostenlos im Google AI Studio erhältlich.",
     "viewInfo": "Klicken für mehr Infos zum Song",
-    "requireKey": "Gemini API-Schlüssel in Einstellungen erforderlich",
+    "requireKey": "KI-Anbieter muss in den Einstellungen konfiguriert werden",
     "settingTitle": "Gemini API-Schlüssel",
     "settingDesc": "Erforderlich für Song-TMI/Infos.",
     "title": "Infos",

--- a/langs/LangEn.js
+++ b/langs/LangEn.js
@@ -1598,7 +1598,7 @@ window.LANG_EN = {
     "getApiKeyDesc": "Get Gemini API Key",
     "getApiKeyInfo": "Used to fetch Trivia. You can get it for free at Google AI Studio.",
     "viewInfo": "Click to see various info about this song",
-    "requireKey": "Gemini API Key needs to be set in settings",
+    "requireKey": "AI provider needs to be configured in settings",
     "settingTitle": "Gemini API Key",
     "settingDesc": "Required to fetch song Trivia/Info.",
     "title": "Trivia",

--- a/langs/LangEs.js
+++ b/langs/LangEs.js
@@ -1597,7 +1597,7 @@ window.LANG_ES = {
     "getApiKeyDesc": "Obtener clave API Gemini",
     "getApiKeyInfo": "Usada para cargar curiosidades (TMI). Gratis en Google AI Studio.",
     "viewInfo": "Haz clic para ver info variada sobre esta canción",
-    "requireKey": "Requiere configurar clave API Gemini en ajustes",
+    "requireKey": "Se necesita configurar un proveedor de IA en ajustes",
     "settingTitle": "Clave API Gemini",
     "settingDesc": "Necesaria para cargar TMI/Info de la canción.",
     "title": "Curiosidades (TMI)",

--- a/langs/LangFa.js
+++ b/langs/LangFa.js
@@ -1596,7 +1596,7 @@ window.LANG_FA = {
     "getApiKeyDesc": "دریافت کلید Gemini API",
     "getApiKeyInfo": "برای بارگذاری TMI استفاده می‌شود. می‌توانید رایگان از Google AI Studio دریافت کنید.",
     "viewInfo": "برای دیدن اطلاعات متنوع درباره این آهنگ کلیک کنید",
-    "requireKey": "نیاز به تنظیم کلید Gemini API در تنظیمات است",
+    "requireKey": "نیاز به پیکربندی ارائه‌دهنده هوش مصنوعی در تنظیمات است",
     "settingTitle": "کلید Gemini API",
     "settingDesc": "برای بارگذاری TMI/اطلاعات آهنگ نیاز است.",
     "title": "TMI",

--- a/langs/LangFr.js
+++ b/langs/LangFr.js
@@ -1597,7 +1597,7 @@ window.LANG_FR = {
     "getApiKeyDesc": "Obtenir Clé API Gemini",
     "getApiKeyInfo": "Utilisé pour charger les infos. Gratuit sur Google AI Studio.",
     "viewInfo": "Cliquez pour voir des infos variées sur ce titre",
-    "requireKey": "Clé API Gemini requise dans les paramètres",
+    "requireKey": "Un fournisseur d'IA doit être configuré dans les paramètres",
     "settingTitle": "Clé API Gemini",
     "settingDesc": "Nécessaire pour charger les TMI/Infos.",
     "title": "Anecdotes",

--- a/langs/LangHi.js
+++ b/langs/LangHi.js
@@ -1596,7 +1596,7 @@ window.LANG_HI = {
     "getApiKeyDesc": "Gemini API कुंजी प्राप्त करें",
     "getApiKeyInfo": "TMI लोड करने के लिए उपयोग किया जाता है। Google AI Studio से मुफ्त।",
     "viewInfo": "गीत के बारे में जानकारी देखने के लिए क्लिक करें",
-    "requireKey": "सेटिंग्स में Gemini API कुंजी आवश्यक है",
+    "requireKey": "सेटिंग्स में AI प्रदाता को कॉन्फ़िगर करना आवश्यक है",
     "settingTitle": "Gemini API कुंजी",
     "settingDesc": "TMI/जानकारी लोड करने के लिए आवश्यक है।",
     "title": "TMI (रोचक तथ्य)",

--- a/langs/LangId.js
+++ b/langs/LangId.js
@@ -1596,7 +1596,7 @@ window.LANG_ID = {
     "getApiKeyDesc": "Dapatkan Kunci API Gemini",
     "getApiKeyInfo": "Digunakan untuk memuat TMI. Gratis dari Google AI Studio.",
     "viewInfo": "Klik untuk melihat berbagai info tentang lagu ini",
-    "requireKey": "Pengaturan Kunci API Gemini diperlukan di pengaturan",
+    "requireKey": "Penyedia AI perlu dikonfigurasi di pengaturan",
     "settingTitle": "Kunci API Gemini",
     "settingDesc": "Diperlukan untuk memuat TMI/Info lagu.",
     "title": "TMI",

--- a/langs/LangIt.js
+++ b/langs/LangIt.js
@@ -1597,7 +1597,7 @@ window.LANG_IT = {
     "getApiKeyDesc": "Ottieni chiave API Gemini",
     "getApiKeyInfo": "Usata per caricare le Curiosità (TMI). Gratuita su Google AI Studio.",
     "viewInfo": "Clicca per vedere varie informazioni su questo brano",
-    "requireKey": "È necessaria la chiave API Gemini nelle impostazioni",
+    "requireKey": "È necessario configurare un provider AI nelle impostazioni",
     "settingTitle": "Chiave API Gemini",
     "settingDesc": "Necessaria per caricare TMI/Info brano.",
     "title": "Curiosità",

--- a/langs/LangJa.js
+++ b/langs/LangJa.js
@@ -1597,7 +1597,7 @@ window.LANG_JA = {
     "getApiKeyDesc": "Gemini APIキーを取得",
     "getApiKeyInfo": "TMIを読み込む際に使用されます。Google AI Studioで無料で取得できます。",
     "viewInfo": "クリックしてこの曲に関する様々な情報を確認",
-    "requireKey": "設定でGemini APIキーの設定が必要です",
+    "requireKey": "設定でAIプロバイダーの設定が必要です",
     "settingTitle": "Gemini APIキー",
     "settingDesc": "曲のTMI/情報を読み込むために必要です。",
     "title": "TMI",

--- a/langs/LangKo.js
+++ b/langs/LangKo.js
@@ -1598,7 +1598,7 @@ window.LANG_KO = {
     "getApiKeyDesc": "Gemini API 키 발급받기",
     "getApiKeyInfo": "TMI를 불러올 때 사용됩니다. Google AI Studio에서 무료로 발급받을 수 있습니다.",
     "viewInfo": "눌러서 이 곡에 대한 다양한 정보를 확인하세요",
-    "requireKey": "설정에서 Gemini API 키 설정이 필요합니다",
+    "requireKey": "설정에서 AI 제공자 설정이 필요합니다",
     "settingTitle": "Gemini API 키",
     "settingDesc": "곡 TMI/정보를 불러오기 위해 필요합니다.",
     "title": "TMI",

--- a/langs/LangPt.js
+++ b/langs/LangPt.js
@@ -1597,7 +1597,7 @@ window.LANG_PT = {
     "getApiKeyDesc": "Obter Chave API Gemini",
     "getApiKeyInfo": "Usado para carregar o TMI. Pode ser obtido gratuitamente no Google AI Studio.",
     "viewInfo": "Clique para ver várias informações sobre esta música",
-    "requireKey": "Necessário configurar a Chave API Gemini nas configurações",
+    "requireKey": "É necessário configurar um provedor de IA nas configurações",
     "settingTitle": "Chave API Gemini",
     "settingDesc": "Necessário para carregar TMI/informações da música.",
     "title": "Curiosidades (TMI)",

--- a/langs/LangRu.js
+++ b/langs/LangRu.js
@@ -1597,7 +1597,7 @@ window.LANG_RU = {
     "getApiKeyDesc": "Получить ключ Gemini API",
     "getApiKeyInfo": "Используется для загрузки TMI. Бесплатно в Google AI Studio.",
     "viewInfo": "Нажмите для просмотра информации о треке",
-    "requireKey": "Требуется настроить ключ Gemini API",
+    "requireKey": "Требуется настроить AI-провайдера в настройках",
     "settingTitle": "Ключ Gemini API",
     "settingDesc": "Нужен для загрузки TMI/Инфо.",
     "title": "TMI",

--- a/langs/LangTh.js
+++ b/langs/LangTh.js
@@ -1597,7 +1597,7 @@ window.LANG_TH = {
     "getApiKeyDesc": "รับ Gemini API Key",
     "getApiKeyInfo": "ใช้สำหรับโหลด TMI สามารถรับได้ฟรีที่ Google AI Studio",
     "viewInfo": "กดเพื่อดูข้อมูลหลากหลายเกี่ยวกับเพลงนี้",
-    "requireKey": "ต้องตั้งค่า Gemini API Key ในการตั้งค่า",
+    "requireKey": "ต้องตั้งค่าผู้ให้บริการ AI ในการตั้งค่า",
     "settingTitle": "Gemini API Key",
     "settingDesc": "จำเป็นสำหรับการโหลด TMI/ข้อมูลเพลง",
     "title": "เกร็ดความรู้ (TMI)",

--- a/langs/LangVi.js
+++ b/langs/LangVi.js
@@ -1597,7 +1597,7 @@ window.LANG_VI = {
     "getApiKeyDesc": "Nhận Gemini API Key",
     "getApiKeyInfo": "Dùng để tải TMI. Bạn có thể nhận miễn phí tại Google AI Studio.",
     "viewInfo": "Nhấn để xem thông tin thú vị về bài hát này",
-    "requireKey": "Cần thiết lập Gemini API Key trong cài đặt",
+    "requireKey": "Cần thiết lập nhà cung cấp AI trong cài đặt",
     "settingTitle": "Gemini API Key",
     "settingDesc": "Cần thiết để tải TMI/Thông tin bài hát.",
     "title": "Thông tin thú vị (TMI)",

--- a/langs/LangZhCN.js
+++ b/langs/LangZhCN.js
@@ -1597,7 +1597,7 @@ window.LANG_ZH_CN = {
     "getApiKeyDesc": "获取 Gemini API 密钥",
     "getApiKeyInfo": "用于加载 TMI。可以在 Google AI Studio 免费获取。",
     "viewInfo": "点击查看关于这首歌的各种信息",
-    "requireKey": "需要在设置中配置 Gemini API 密钥",
+    "requireKey": "需要在设置中配置 AI 提供商",
     "settingTitle": "Gemini API 密钥",
     "settingDesc": "加载歌曲 TMI/信息所需。",
     "title": "TMI (歌曲情报)",

--- a/langs/LangZhTW.js
+++ b/langs/LangZhTW.js
@@ -1597,7 +1597,7 @@ window.LANG_ZH_TW = {
     "getApiKeyDesc": "取得 Gemini API 金鑰",
     "getApiKeyInfo": "用於載入 TMI。可在 Google AI Studio 免費取得。",
     "viewInfo": "點擊以查看此歌曲的各種資訊",
-    "requireKey": "需要在設定中設定 Gemini API 金鑰",
+    "requireKey": "需要在設定中設定 AI 提供者",
     "settingTitle": "Gemini API 金鑰",
     "settingDesc": "用於載入歌曲 TMI/資訊。",
     "title": "TMI",


### PR DESCRIPTION
- Remove hardcoded Gemini API key checks in FullscreenOverlay.js
- Use AIAddonManager.getEnabledProvidersFor('tmi') for provider detection
- Add ignoreCache parameter support to LyricsService.getTMI() for regeneration
- Update all 18 language files with provider-agnostic error messages

Features:
- TMI now works with any AI provider (ChatGPT, Claude, Groq, OpenRouter, etc.)
- Automatic fallback to next provider if one fails
- TMI regenerate button now properly bypasses cache
- Consistent error messages across all supported languages

Fixes:
- TMI feature was locked to Gemini API only
- TMI regenerate button did not work (always used cached data)