### PR TITLE
feat: Add CLI proxy providers (Claude Code, Codex CLI, Gemini CLI)

### DIFF
--- a/Addon_AI_CLI_ClaudeCode.js
+++ b/Addon_AI_CLI_ClaudeCode.js
@@ -1,0 +1,451 @@
+/**
+ * Claude Code CLI Addon for ivLyrics
+ * Anthropic Claude Code CLI를 프록시 서버를 통해 사용
+ *
+ * @author ivLis STUDIO
+ * @version 1.0.0
+ *
+ * 사용하려면:
+ * 1. ~/.config/spicetify/cli-proxy 폴더에서 npm install && npm start
+ * 2. ivLyrics 설정에서 Claude Code (CLI) 활성화
+ */
+
+(() => {
+    'use strict';
+
+    const ADDON_INFO = {
+        id: 'cli-claude',
+        name: 'Claude Code (CLI)',
+        author: 'ivLis STUDIO',
+        description: {
+            ko: 'Anthropic Claude Code CLI를 프록시 서버를 통해 사용',
+            en: 'Use Anthropic Claude Code CLI via proxy server',
+            ja: 'Anthropic Claude Code CLIをプロキシサーバー経由で使用',
+            'zh-CN': '通过代理服务器使用 Anthropic Claude Code CLI',
+        },
+        version: '1.0.0',
+        supports: {
+            translate: true,
+            metadata: true,
+            tmi: true
+        }
+    };
+
+    const TOOL_ID = 'claude';
+    const DEFAULT_PROXY_URL = 'http://localhost:19284';
+    const MODEL_HINT = 'Default: claude-sonnet-4-5. Others: opus, haiku';
+
+    const LANGUAGE_DATA = {
+        'ko': { name: 'Korean', native: '한국어' },
+        'en': { name: 'English', native: 'English' },
+        'zh-CN': { name: 'Simplified Chinese', native: '简体中文' },
+        'zh-TW': { name: 'Traditional Chinese', native: '繁體中文' },
+        'ja': { name: 'Japanese', native: '日本語' },
+        'hi': { name: 'Hindi', native: 'हिन्दी' },
+        'es': { name: 'Spanish', native: 'Español' },
+        'fr': { name: 'French', native: 'Français' },
+        'ar': { name: 'Arabic', native: 'العربية' },
+        'fa': { name: 'Persian', native: 'فارسی' },
+        'de': { name: 'German', native: 'Deutsch' },
+        'ru': { name: 'Russian', native: 'Русский' },
+        'pt': { name: 'Portuguese', native: 'Português' },
+        'bn': { name: 'Bengali', native: 'বাংলা' },
+        'it': { name: 'Italian', native: 'Italiano' },
+        'th': { name: 'Thai', native: 'ไทย' },
+        'vi': { name: 'Vietnamese', native: 'Tiếng Việt' },
+        'id': { name: 'Indonesian', native: 'Bahasa Indonesia' }
+    };
+
+    function getSetting(key, defaultValue = null) {
+        return window.AIAddonManager?.getAddonSetting(ADDON_INFO.id, key, defaultValue) ?? defaultValue;
+    }
+
+    function setSetting(key, value) {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.setAddonSetting(ADDON_INFO.id, key, value);
+        }
+    }
+
+    function getProxyUrl() {
+        return getSetting('proxy-url', DEFAULT_PROXY_URL) || DEFAULT_PROXY_URL;
+    }
+
+    function getSelectedModel() {
+        return getSetting('model', '');
+    }
+
+    function getLangInfo(lang) {
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
+    }
+
+    // ============================================
+    // Prompt Builders
+    // ============================================
+
+    function buildTranslationPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+
+        return `Translate these ${lineCount} lines of song lyrics to ${langInfo.name} (${langInfo.native}).
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one translation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the translated lines, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildPhoneticPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+        const isEnglish = lang === 'en';
+        const scriptInstruction = isEnglish
+            ? 'Use Latin alphabet only (romanization).'
+            : `Use ${langInfo.native} script.`;
+
+        return `Convert these ${lineCount} lines of lyrics to pronunciation for ${langInfo.name} speakers.
+${scriptInstruction}
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one pronunciation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the pronunciations, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildMetadataPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `Translate the song title and artist name to ${langInfo.name} (${langInfo.native}).
+
+**Input**:
+- Title: ${title}
+- Artist: ${artist}
+
+**Output valid JSON**:
+{
+  "translatedTitle": "translated title",
+  "translatedArtist": "translated artist",
+  "romanizedTitle": "romanized in Latin alphabet",
+  "romanizedArtist": "romanized in Latin alphabet"
+}`;
+    }
+
+    function buildTMIPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
+
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+
+**Output JSON Structure**:
+{
+  "track": {
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
+  }
+}
+
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Do NOT use markdown code blocks`;
+    }
+
+    // ============================================
+    // API Functions
+    // ============================================
+
+    async function checkProxyHealth() {
+        const proxyUrl = getProxyUrl();
+        try {
+            const response = await fetch(`${proxyUrl}/health`, { timeout: 5000 });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } catch (e) {
+            throw new Error(`Proxy server not running at ${proxyUrl}. Start with: cd cli-proxy && npm start`);
+        }
+    }
+
+    async function callProxy(prompt, maxRetries = 2) {
+        const proxyUrl = getProxyUrl();
+        const model = getSelectedModel();
+        let lastError = null;
+
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                const response = await fetch(`${proxyUrl}/generate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        tool: TOOL_ID,
+                        model,
+                        prompt,
+                        timeout: 120000
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
+
+                const data = await response.json();
+                if (!data.success || !data.result) {
+                    throw new Error(data.error || 'Empty response from CLI');
+                }
+
+                return data.result;
+
+            } catch (e) {
+                lastError = e;
+                console.warn(`[Claude Code CLI] Attempt ${attempt + 1} failed:`, e.message);
+
+                if (e.message.includes('not running') || e.message.includes('ECONNREFUSED')) {
+                    throw new Error(`[Claude Code CLI] Server not running. Start with: cd cli-proxy && npm start`);
+                }
+
+                if (attempt < maxRetries - 1) {
+                    await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+                }
+            }
+        }
+
+        throw lastError || new Error('[Claude Code CLI] All retries exhausted');
+    }
+
+    function parseTextLines(text, expectedLineCount) {
+        let cleaned = text.replace(/```[a-z]*\s*/gi, '').replace(/```\s*/g, '').trim();
+        const lines = cleaned.split('\n');
+
+        if (lines.length === expectedLineCount) {
+            return lines;
+        }
+
+        if (lines.length > expectedLineCount) {
+            return lines.slice(-expectedLineCount);
+        }
+
+        while (lines.length < expectedLineCount) {
+            lines.push('');
+        }
+
+        return lines;
+    }
+
+    function extractJSON(text) {
+        let cleaned = text.replace(/```json\s*/gi, '').replace(/```\s*/g, '').trim();
+
+        try {
+            return JSON.parse(cleaned);
+        } catch {
+            const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+                try {
+                    return JSON.parse(jsonMatch[0]);
+                } catch { }
+            }
+        }
+        return null;
+    }
+
+    // ============================================
+    // Addon Implementation
+    // ============================================
+
+    const ClaudeCodeAddon = {
+        ...ADDON_INFO,
+
+        async init() {
+            console.log(`[Claude Code CLI] Initialized (v${ADDON_INFO.version})`);
+        },
+
+        async testConnection() {
+            const health = await checkProxyHealth();
+
+            if (!health.tools?.[TOOL_ID]?.available) {
+                throw new Error(`Claude Code CLI is not available. Make sure it's installed.`);
+            }
+
+            await callProxy('Say "OK" if you receive this.');
+        },
+
+        getSettingsUI() {
+            const React = Spicetify.React;
+            const { useState, useCallback } = React;
+
+            return function ClaudeCodeSettings() {
+                const [proxyUrl, setProxyUrl] = useState(getSetting('proxy-url', DEFAULT_PROXY_URL));
+                const [selectedModel, setSelectedModel] = useState(getSetting('model', ''));
+                const [testStatus, setTestStatus] = useState('');
+
+                const handleProxyUrlChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setProxyUrl(value);
+                    setSetting('proxy-url', value);
+                }, []);
+
+                const handleModelChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setSelectedModel(value);
+                    setSetting('model', value);
+                }, []);
+
+                const handleTest = useCallback(async () => {
+                    setTestStatus('Testing...');
+                    try {
+                        await ClaudeCodeAddon.testConnection();
+                        setTestStatus('✓ Connection successful!');
+                    } catch (e) {
+                        setTestStatus(`✗ ${e.message}`);
+                    }
+                }, []);
+
+                return React.createElement('div', { className: 'ai-addon-settings' },
+                    React.createElement('div', {
+                        className: 'ai-addon-notice',
+                        style: {
+                            padding: '12px',
+                            marginBottom: '16px',
+                            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                            borderRadius: '4px',
+                            fontSize: '12px'
+                        }
+                    },
+                        React.createElement('strong', null, 'Setup Required:'),
+                        React.createElement('br'),
+                        React.createElement('code', { style: { fontSize: '11px' } },
+                            'cd ~/.config/spicetify/cli-proxy && npm install && npm start')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Proxy Server URL'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: proxyUrl,
+                            onChange: handleProxyUrlChange,
+                            placeholder: DEFAULT_PROXY_URL
+                        }),
+                        React.createElement('small', null, 'Default: http://localhost:19284')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Model'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: selectedModel,
+                            onChange: handleModelChange,
+                            placeholder: 'Leave empty for default'
+                        }),
+                        React.createElement('small', null, MODEL_HINT)
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('button', {
+                            onClick: handleTest,
+                            className: 'ai-addon-btn-primary'
+                        }, 'Test Connection'),
+                        testStatus && React.createElement('span', {
+                            className: `ai-addon-test-status ${testStatus.startsWith('✓') ? 'success' : testStatus.startsWith('✗') ? 'error' : ''}`
+                        }, testStatus)
+                    )
+                );
+            };
+        },
+
+        async translateLyrics({ text, lang, wantSmartPhonetic }) {
+            if (!text?.trim()) {
+                throw new Error('No text provided');
+            }
+
+            const expectedLineCount = text.split('\n').length;
+            const prompt = wantSmartPhonetic
+                ? buildPhoneticPrompt(text, lang)
+                : buildTranslationPrompt(text, lang);
+
+            const rawResponse = await callProxy(prompt);
+            const lines = parseTextLines(rawResponse, expectedLineCount);
+
+            if (wantSmartPhonetic) {
+                return { phonetic: lines };
+            } else {
+                return { translation: lines };
+            }
+        },
+
+        async translateMetadata({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildMetadataPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            const result = extractJSON(rawResponse);
+
+            return {
+                translated: {
+                    title: result?.translatedTitle || title,
+                    artist: result?.translatedArtist || artist
+                },
+                romanized: {
+                    title: result?.romanizedTitle || title,
+                    artist: result?.romanizedArtist || artist
+                }
+            };
+        },
+
+        async generateTMI({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildTMIPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            return extractJSON(rawResponse);
+        }
+    };
+
+    const registerAddon = () => {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.register(ClaudeCodeAddon);
+        } else {
+            setTimeout(registerAddon, 100);
+        }
+    };
+
+    registerAddon();
+
+    console.log('[Claude Code CLI] Module loaded');
+})();

--- a/Addon_AI_CLI_CodexCLI.js
+++ b/Addon_AI_CLI_CodexCLI.js
@@ -1,0 +1,451 @@
+/**
+ * Codex CLI Addon for ivLyrics
+ * OpenAI Codex CLI를 프록시 서버를 통해 사용
+ *
+ * @author ivLis STUDIO
+ * @version 1.0.0
+ *
+ * 사용하려면:
+ * 1. ~/.config/spicetify/cli-proxy 폴더에서 npm install && npm start
+ * 2. ivLyrics 설정에서 Codex CLI 활성화
+ */
+
+(() => {
+    'use strict';
+
+    const ADDON_INFO = {
+        id: 'cli-codex',
+        name: 'Codex CLI (OpenAI)',
+        author: 'ivLis STUDIO',
+        description: {
+            ko: 'OpenAI Codex CLI를 프록시 서버를 통해 사용',
+            en: 'Use OpenAI Codex CLI via proxy server',
+            ja: 'OpenAI Codex CLIをプロキシサーバー経由で使用',
+            'zh-CN': '通过代理服务器使用 OpenAI Codex CLI',
+        },
+        version: '1.0.0',
+        supports: {
+            translate: true,
+            metadata: true,
+            tmi: true
+        }
+    };
+
+    const TOOL_ID = 'codex';
+    const DEFAULT_PROXY_URL = 'http://localhost:19284';
+    const MODEL_HINT = 'Leave empty for Codex default';
+
+    const LANGUAGE_DATA = {
+        'ko': { name: 'Korean', native: '한국어' },
+        'en': { name: 'English', native: 'English' },
+        'zh-CN': { name: 'Simplified Chinese', native: '简体中文' },
+        'zh-TW': { name: 'Traditional Chinese', native: '繁體中文' },
+        'ja': { name: 'Japanese', native: '日本語' },
+        'hi': { name: 'Hindi', native: 'हिन्दी' },
+        'es': { name: 'Spanish', native: 'Español' },
+        'fr': { name: 'French', native: 'Français' },
+        'ar': { name: 'Arabic', native: 'العربية' },
+        'fa': { name: 'Persian', native: 'فارسی' },
+        'de': { name: 'German', native: 'Deutsch' },
+        'ru': { name: 'Russian', native: 'Русский' },
+        'pt': { name: 'Portuguese', native: 'Português' },
+        'bn': { name: 'Bengali', native: 'বাংলা' },
+        'it': { name: 'Italian', native: 'Italiano' },
+        'th': { name: 'Thai', native: 'ไทย' },
+        'vi': { name: 'Vietnamese', native: 'Tiếng Việt' },
+        'id': { name: 'Indonesian', native: 'Bahasa Indonesia' }
+    };
+
+    function getSetting(key, defaultValue = null) {
+        return window.AIAddonManager?.getAddonSetting(ADDON_INFO.id, key, defaultValue) ?? defaultValue;
+    }
+
+    function setSetting(key, value) {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.setAddonSetting(ADDON_INFO.id, key, value);
+        }
+    }
+
+    function getProxyUrl() {
+        return getSetting('proxy-url', DEFAULT_PROXY_URL) || DEFAULT_PROXY_URL;
+    }
+
+    function getSelectedModel() {
+        return getSetting('model', '');
+    }
+
+    function getLangInfo(lang) {
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
+    }
+
+    // ============================================
+    // Prompt Builders
+    // ============================================
+
+    function buildTranslationPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+
+        return `Translate these ${lineCount} lines of song lyrics to ${langInfo.name} (${langInfo.native}).
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one translation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the translated lines, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildPhoneticPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+        const isEnglish = lang === 'en';
+        const scriptInstruction = isEnglish
+            ? 'Use Latin alphabet only (romanization).'
+            : `Use ${langInfo.native} script.`;
+
+        return `Convert these ${lineCount} lines of lyrics to pronunciation for ${langInfo.name} speakers.
+${scriptInstruction}
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one pronunciation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the pronunciations, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildMetadataPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `Translate the song title and artist name to ${langInfo.name} (${langInfo.native}).
+
+**Input**:
+- Title: ${title}
+- Artist: ${artist}
+
+**Output valid JSON**:
+{
+  "translatedTitle": "translated title",
+  "translatedArtist": "translated artist",
+  "romanizedTitle": "romanized in Latin alphabet",
+  "romanizedArtist": "romanized in Latin alphabet"
+}`;
+    }
+
+    function buildTMIPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
+
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+
+**Output JSON Structure**:
+{
+  "track": {
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
+  }
+}
+
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Do NOT use markdown code blocks`;
+    }
+
+    // ============================================
+    // API Functions
+    // ============================================
+
+    async function checkProxyHealth() {
+        const proxyUrl = getProxyUrl();
+        try {
+            const response = await fetch(`${proxyUrl}/health`, { timeout: 5000 });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } catch (e) {
+            throw new Error(`Proxy server not running at ${proxyUrl}. Start with: cd cli-proxy && npm start`);
+        }
+    }
+
+    async function callProxy(prompt, maxRetries = 2) {
+        const proxyUrl = getProxyUrl();
+        const model = getSelectedModel();
+        let lastError = null;
+
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                const response = await fetch(`${proxyUrl}/generate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        tool: TOOL_ID,
+                        model,
+                        prompt,
+                        timeout: 120000
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
+
+                const data = await response.json();
+                if (!data.success || !data.result) {
+                    throw new Error(data.error || 'Empty response from CLI');
+                }
+
+                return data.result;
+
+            } catch (e) {
+                lastError = e;
+                console.warn(`[Codex CLI] Attempt ${attempt + 1} failed:`, e.message);
+
+                if (e.message.includes('not running') || e.message.includes('ECONNREFUSED')) {
+                    throw new Error(`[Codex CLI] Server not running. Start with: cd cli-proxy && npm start`);
+                }
+
+                if (attempt < maxRetries - 1) {
+                    await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+                }
+            }
+        }
+
+        throw lastError || new Error('[Codex CLI] All retries exhausted');
+    }
+
+    function parseTextLines(text, expectedLineCount) {
+        let cleaned = text.replace(/```[a-z]*\s*/gi, '').replace(/```\s*/g, '').trim();
+        const lines = cleaned.split('\n');
+
+        if (lines.length === expectedLineCount) {
+            return lines;
+        }
+
+        if (lines.length > expectedLineCount) {
+            return lines.slice(-expectedLineCount);
+        }
+
+        while (lines.length < expectedLineCount) {
+            lines.push('');
+        }
+
+        return lines;
+    }
+
+    function extractJSON(text) {
+        let cleaned = text.replace(/```json\s*/gi, '').replace(/```\s*/g, '').trim();
+
+        try {
+            return JSON.parse(cleaned);
+        } catch {
+            const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+                try {
+                    return JSON.parse(jsonMatch[0]);
+                } catch { }
+            }
+        }
+        return null;
+    }
+
+    // ============================================
+    // Addon Implementation
+    // ============================================
+
+    const CodexCLIAddon = {
+        ...ADDON_INFO,
+
+        async init() {
+            console.log(`[Codex CLI] Initialized (v${ADDON_INFO.version})`);
+        },
+
+        async testConnection() {
+            const health = await checkProxyHealth();
+
+            if (!health.tools?.[TOOL_ID]?.available) {
+                throw new Error(`Codex CLI is not available. Make sure it's installed.`);
+            }
+
+            await callProxy('Say "OK" if you receive this.');
+        },
+
+        getSettingsUI() {
+            const React = Spicetify.React;
+            const { useState, useCallback } = React;
+
+            return function CodexCLISettings() {
+                const [proxyUrl, setProxyUrl] = useState(getSetting('proxy-url', DEFAULT_PROXY_URL));
+                const [selectedModel, setSelectedModel] = useState(getSetting('model', ''));
+                const [testStatus, setTestStatus] = useState('');
+
+                const handleProxyUrlChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setProxyUrl(value);
+                    setSetting('proxy-url', value);
+                }, []);
+
+                const handleModelChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setSelectedModel(value);
+                    setSetting('model', value);
+                }, []);
+
+                const handleTest = useCallback(async () => {
+                    setTestStatus('Testing...');
+                    try {
+                        await CodexCLIAddon.testConnection();
+                        setTestStatus('✓ Connection successful!');
+                    } catch (e) {
+                        setTestStatus(`✗ ${e.message}`);
+                    }
+                }, []);
+
+                return React.createElement('div', { className: 'ai-addon-settings' },
+                    React.createElement('div', {
+                        className: 'ai-addon-notice',
+                        style: {
+                            padding: '12px',
+                            marginBottom: '16px',
+                            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                            borderRadius: '4px',
+                            fontSize: '12px'
+                        }
+                    },
+                        React.createElement('strong', null, 'Setup Required:'),
+                        React.createElement('br'),
+                        React.createElement('code', { style: { fontSize: '11px' } },
+                            'cd ~/.config/spicetify/cli-proxy && npm install && npm start')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Proxy Server URL'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: proxyUrl,
+                            onChange: handleProxyUrlChange,
+                            placeholder: DEFAULT_PROXY_URL
+                        }),
+                        React.createElement('small', null, 'Default: http://localhost:19284')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Model'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: selectedModel,
+                            onChange: handleModelChange,
+                            placeholder: 'Leave empty for default'
+                        }),
+                        React.createElement('small', null, MODEL_HINT)
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('button', {
+                            onClick: handleTest,
+                            className: 'ai-addon-btn-primary'
+                        }, 'Test Connection'),
+                        testStatus && React.createElement('span', {
+                            className: `ai-addon-test-status ${testStatus.startsWith('✓') ? 'success' : testStatus.startsWith('✗') ? 'error' : ''}`
+                        }, testStatus)
+                    )
+                );
+            };
+        },
+
+        async translateLyrics({ text, lang, wantSmartPhonetic }) {
+            if (!text?.trim()) {
+                throw new Error('No text provided');
+            }
+
+            const expectedLineCount = text.split('\n').length;
+            const prompt = wantSmartPhonetic
+                ? buildPhoneticPrompt(text, lang)
+                : buildTranslationPrompt(text, lang);
+
+            const rawResponse = await callProxy(prompt);
+            const lines = parseTextLines(rawResponse, expectedLineCount);
+
+            if (wantSmartPhonetic) {
+                return { phonetic: lines };
+            } else {
+                return { translation: lines };
+            }
+        },
+
+        async translateMetadata({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildMetadataPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            const result = extractJSON(rawResponse);
+
+            return {
+                translated: {
+                    title: result?.translatedTitle || title,
+                    artist: result?.translatedArtist || artist
+                },
+                romanized: {
+                    title: result?.romanizedTitle || title,
+                    artist: result?.romanizedArtist || artist
+                }
+            };
+        },
+
+        async generateTMI({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildTMIPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            return extractJSON(rawResponse);
+        }
+    };
+
+    const registerAddon = () => {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.register(CodexCLIAddon);
+        } else {
+            setTimeout(registerAddon, 100);
+        }
+    };
+
+    registerAddon();
+
+    console.log('[Codex CLI] Module loaded');
+})();

--- a/Addon_AI_CLI_GeminiCLI.js
+++ b/Addon_AI_CLI_GeminiCLI.js
@@ -1,0 +1,451 @@
+/**
+ * Gemini CLI Addon for ivLyrics
+ * Google Gemini CLI를 프록시 서버를 통해 사용
+ *
+ * @author ivLis STUDIO
+ * @version 1.0.0
+ *
+ * 사용하려면:
+ * 1. ~/.config/spicetify/cli-proxy 폴더에서 npm install && npm start
+ * 2. ivLyrics 설정에서 Gemini CLI 활성화
+ */
+
+(() => {
+    'use strict';
+
+    const ADDON_INFO = {
+        id: 'cli-gemini',
+        name: 'Gemini CLI (Google)',
+        author: 'ivLis STUDIO',
+        description: {
+            ko: 'Google Gemini CLI를 프록시 서버를 통해 사용',
+            en: 'Use Google Gemini CLI via proxy server',
+            ja: 'Google Gemini CLIをプロキシサーバー経由で使用',
+            'zh-CN': '通过代理服务器使用 Google Gemini CLI',
+        },
+        version: '1.0.0',
+        supports: {
+            translate: true,
+            metadata: true,
+            tmi: true
+        }
+    };
+
+    const TOOL_ID = 'gemini';
+    const DEFAULT_PROXY_URL = 'http://localhost:19284';
+    const MODEL_HINT = 'Default: gemini-3-flash-preview. Others: gemini-2.5-pro';
+
+    const LANGUAGE_DATA = {
+        'ko': { name: 'Korean', native: '한국어' },
+        'en': { name: 'English', native: 'English' },
+        'zh-CN': { name: 'Simplified Chinese', native: '简体中文' },
+        'zh-TW': { name: 'Traditional Chinese', native: '繁體中文' },
+        'ja': { name: 'Japanese', native: '日本語' },
+        'hi': { name: 'Hindi', native: 'हिन्दी' },
+        'es': { name: 'Spanish', native: 'Español' },
+        'fr': { name: 'French', native: 'Français' },
+        'ar': { name: 'Arabic', native: 'العربية' },
+        'fa': { name: 'Persian', native: 'فارسی' },
+        'de': { name: 'German', native: 'Deutsch' },
+        'ru': { name: 'Russian', native: 'Русский' },
+        'pt': { name: 'Portuguese', native: 'Português' },
+        'bn': { name: 'Bengali', native: 'বাংলা' },
+        'it': { name: 'Italian', native: 'Italiano' },
+        'th': { name: 'Thai', native: 'ไทย' },
+        'vi': { name: 'Vietnamese', native: 'Tiếng Việt' },
+        'id': { name: 'Indonesian', native: 'Bahasa Indonesia' }
+    };
+
+    function getSetting(key, defaultValue = null) {
+        return window.AIAddonManager?.getAddonSetting(ADDON_INFO.id, key, defaultValue) ?? defaultValue;
+    }
+
+    function setSetting(key, value) {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.setAddonSetting(ADDON_INFO.id, key, value);
+        }
+    }
+
+    function getProxyUrl() {
+        return getSetting('proxy-url', DEFAULT_PROXY_URL) || DEFAULT_PROXY_URL;
+    }
+
+    function getSelectedModel() {
+        return getSetting('model', '');
+    }
+
+    function getLangInfo(lang) {
+        if (!lang) return LANGUAGE_DATA['en'];
+        const shortLang = lang.split('-')[0].toLowerCase();
+        return LANGUAGE_DATA[lang] || LANGUAGE_DATA[shortLang] || LANGUAGE_DATA['en'];
+    }
+
+    // ============================================
+    // Prompt Builders
+    // ============================================
+
+    function buildTranslationPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+
+        return `Translate these ${lineCount} lines of song lyrics to ${langInfo.name} (${langInfo.native}).
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one translation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the translated lines, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildPhoneticPrompt(text, lang) {
+        const langInfo = getLangInfo(lang);
+        const lineCount = text.split('\n').length;
+        const isEnglish = lang === 'en';
+        const scriptInstruction = isEnglish
+            ? 'Use Latin alphabet only (romanization).'
+            : `Use ${langInfo.native} script.`;
+
+        return `Convert these ${lineCount} lines of lyrics to pronunciation for ${langInfo.name} speakers.
+${scriptInstruction}
+
+RULES:
+- Output EXACTLY ${lineCount} lines, one pronunciation per line
+- Keep empty lines as empty
+- Keep ♪ symbols and markers like [Chorus], (Yeah) as-is
+- Do NOT add line numbers or prefixes
+- Do NOT use JSON or code blocks
+- Just output the pronunciations, nothing else
+
+INPUT:
+${text}
+
+OUTPUT (${lineCount} lines):`;
+    }
+
+    function buildMetadataPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `Translate the song title and artist name to ${langInfo.name} (${langInfo.native}).
+
+**Input**:
+- Title: ${title}
+- Artist: ${artist}
+
+**Output valid JSON**:
+{
+  "translatedTitle": "translated title",
+  "translatedArtist": "translated artist",
+  "romanizedTitle": "romanized in Latin alphabet",
+  "romanizedArtist": "romanized in Latin alphabet"
+}`;
+    }
+
+    function buildTMIPrompt(title, artist, lang) {
+        const langInfo = getLangInfo(lang);
+
+        return `You are a music knowledge expert. Generate interesting facts and trivia about the song "${title}" by "${artist}".
+
+IMPORTANT: The output MUST be in ${langInfo.name} (${langInfo.native}).
+
+**Output JSON Structure**:
+{
+  "track": {
+    "description": "2-3 sentence description in ${langInfo.native}",
+    "trivia": [
+      "Fact 1 in ${langInfo.native}",
+      "Fact 2 in ${langInfo.native}",
+      "Fact 3 in ${langInfo.native}"
+    ],
+    "sources": {
+      "verified": [],
+      "related": [],
+      "other": []
+    },
+    "reliability": {
+      "confidence": "medium",
+      "has_verified_sources": false,
+      "verified_source_count": 0,
+      "related_source_count": 0,
+      "total_source_count": 0
+    }
+  }
+}
+
+**Rules**:
+1. Write in ${langInfo.native}
+2. Include 3-5 interesting facts in the trivia array
+3. Do NOT use markdown code blocks`;
+    }
+
+    // ============================================
+    // API Functions
+    // ============================================
+
+    async function checkProxyHealth() {
+        const proxyUrl = getProxyUrl();
+        try {
+            const response = await fetch(`${proxyUrl}/health`, { timeout: 5000 });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } catch (e) {
+            throw new Error(`Proxy server not running at ${proxyUrl}. Start with: cd cli-proxy && npm start`);
+        }
+    }
+
+    async function callProxy(prompt, maxRetries = 2) {
+        const proxyUrl = getProxyUrl();
+        const model = getSelectedModel();
+        let lastError = null;
+
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                const response = await fetch(`${proxyUrl}/generate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        tool: TOOL_ID,
+                        model,
+                        prompt,
+                        timeout: 120000
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    throw new Error(errorData.error || `HTTP ${response.status}`);
+                }
+
+                const data = await response.json();
+                if (!data.success || !data.result) {
+                    throw new Error(data.error || 'Empty response from CLI');
+                }
+
+                return data.result;
+
+            } catch (e) {
+                lastError = e;
+                console.warn(`[Gemini CLI] Attempt ${attempt + 1} failed:`, e.message);
+
+                if (e.message.includes('not running') || e.message.includes('ECONNREFUSED')) {
+                    throw new Error(`[Gemini CLI] Server not running. Start with: cd cli-proxy && npm start`);
+                }
+
+                if (attempt < maxRetries - 1) {
+                    await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+                }
+            }
+        }
+
+        throw lastError || new Error('[Gemini CLI] All retries exhausted');
+    }
+
+    function parseTextLines(text, expectedLineCount) {
+        let cleaned = text.replace(/```[a-z]*\s*/gi, '').replace(/```\s*/g, '').trim();
+        const lines = cleaned.split('\n');
+
+        if (lines.length === expectedLineCount) {
+            return lines;
+        }
+
+        if (lines.length > expectedLineCount) {
+            return lines.slice(-expectedLineCount);
+        }
+
+        while (lines.length < expectedLineCount) {
+            lines.push('');
+        }
+
+        return lines;
+    }
+
+    function extractJSON(text) {
+        let cleaned = text.replace(/```json\s*/gi, '').replace(/```\s*/g, '').trim();
+
+        try {
+            return JSON.parse(cleaned);
+        } catch {
+            const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
+            if (jsonMatch) {
+                try {
+                    return JSON.parse(jsonMatch[0]);
+                } catch { }
+            }
+        }
+        return null;
+    }
+
+    // ============================================
+    // Addon Implementation
+    // ============================================
+
+    const GeminiCLIAddon = {
+        ...ADDON_INFO,
+
+        async init() {
+            console.log(`[Gemini CLI] Initialized (v${ADDON_INFO.version})`);
+        },
+
+        async testConnection() {
+            const health = await checkProxyHealth();
+
+            if (!health.tools?.[TOOL_ID]?.available) {
+                throw new Error(`Gemini CLI is not available. Make sure it's installed.`);
+            }
+
+            await callProxy('Say "OK" if you receive this.');
+        },
+
+        getSettingsUI() {
+            const React = Spicetify.React;
+            const { useState, useCallback } = React;
+
+            return function GeminiCLISettings() {
+                const [proxyUrl, setProxyUrl] = useState(getSetting('proxy-url', DEFAULT_PROXY_URL));
+                const [selectedModel, setSelectedModel] = useState(getSetting('model', ''));
+                const [testStatus, setTestStatus] = useState('');
+
+                const handleProxyUrlChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setProxyUrl(value);
+                    setSetting('proxy-url', value);
+                }, []);
+
+                const handleModelChange = useCallback((e) => {
+                    const value = e.target.value;
+                    setSelectedModel(value);
+                    setSetting('model', value);
+                }, []);
+
+                const handleTest = useCallback(async () => {
+                    setTestStatus('Testing...');
+                    try {
+                        await GeminiCLIAddon.testConnection();
+                        setTestStatus('✓ Connection successful!');
+                    } catch (e) {
+                        setTestStatus(`✗ ${e.message}`);
+                    }
+                }, []);
+
+                return React.createElement('div', { className: 'ai-addon-settings' },
+                    React.createElement('div', {
+                        className: 'ai-addon-notice',
+                        style: {
+                            padding: '12px',
+                            marginBottom: '16px',
+                            backgroundColor: 'rgba(255, 255, 255, 0.05)',
+                            borderRadius: '4px',
+                            fontSize: '12px'
+                        }
+                    },
+                        React.createElement('strong', null, 'Setup Required:'),
+                        React.createElement('br'),
+                        React.createElement('code', { style: { fontSize: '11px' } },
+                            'cd ~/.config/spicetify/cli-proxy && npm install && npm start')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Proxy Server URL'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: proxyUrl,
+                            onChange: handleProxyUrlChange,
+                            placeholder: DEFAULT_PROXY_URL
+                        }),
+                        React.createElement('small', null, 'Default: http://localhost:19284')
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('label', null, 'Model'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: selectedModel,
+                            onChange: handleModelChange,
+                            placeholder: 'Leave empty for default'
+                        }),
+                        React.createElement('small', null, MODEL_HINT)
+                    ),
+
+                    React.createElement('div', { className: 'ai-addon-setting' },
+                        React.createElement('button', {
+                            onClick: handleTest,
+                            className: 'ai-addon-btn-primary'
+                        }, 'Test Connection'),
+                        testStatus && React.createElement('span', {
+                            className: `ai-addon-test-status ${testStatus.startsWith('✓') ? 'success' : testStatus.startsWith('✗') ? 'error' : ''}`
+                        }, testStatus)
+                    )
+                );
+            };
+        },
+
+        async translateLyrics({ text, lang, wantSmartPhonetic }) {
+            if (!text?.trim()) {
+                throw new Error('No text provided');
+            }
+
+            const expectedLineCount = text.split('\n').length;
+            const prompt = wantSmartPhonetic
+                ? buildPhoneticPrompt(text, lang)
+                : buildTranslationPrompt(text, lang);
+
+            const rawResponse = await callProxy(prompt);
+            const lines = parseTextLines(rawResponse, expectedLineCount);
+
+            if (wantSmartPhonetic) {
+                return { phonetic: lines };
+            } else {
+                return { translation: lines };
+            }
+        },
+
+        async translateMetadata({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildMetadataPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            const result = extractJSON(rawResponse);
+
+            return {
+                translated: {
+                    title: result?.translatedTitle || title,
+                    artist: result?.translatedArtist || artist
+                },
+                romanized: {
+                    title: result?.romanizedTitle || title,
+                    artist: result?.romanizedArtist || artist
+                }
+            };
+        },
+
+        async generateTMI({ title, artist, lang }) {
+            if (!title || !artist) {
+                throw new Error('Title and artist are required');
+            }
+
+            const prompt = buildTMIPrompt(title, artist, lang);
+            const rawResponse = await callProxy(prompt);
+            return extractJSON(rawResponse);
+        }
+    };
+
+    const registerAddon = () => {
+        if (window.AIAddonManager) {
+            window.AIAddonManager.register(GeminiCLIAddon);
+        } else {
+            setTimeout(registerAddon, 100);
+        }
+    };
+
+    registerAddon();
+
+    console.log('[Gemini CLI] Module loaded');
+})();

--- a/cli-proxy/README.md
+++ b/cli-proxy/README.md
@@ -1,0 +1,89 @@
+# ivLyrics CLI Proxy Server
+
+로컬 CLI AI 도구들 (Claude Code, Codex, Gemini CLI)을 ivLyrics에서 사용할 수 있게 해주는 프록시 서버입니다.
+
+## 지원 CLI 도구
+
+| Tool | Command | Provider | Description |
+|------|---------|----------|-------------|
+| **Claude Code** | `claude` | Anthropic | Claude Pro/Max 구독자용 CLI |
+| **Codex CLI** | `codex` | OpenAI | ChatGPT Pro 구독자용 CLI |
+| **Gemini CLI** | `gemini` | Google | Google AI Pro/Ultra 구독자용 CLI |
+
+## 설치
+
+```bash
+cd ~/.config/spicetify/cli-proxy
+npm install
+```
+
+## 실행
+
+```bash
+npm start
+```
+
+서버가 `http://localhost:19284`에서 시작됩니다.
+
+## 사용법
+
+1. 프록시 서버를 실행합니다
+2. Spotify에서 ivLyrics 설정으로 이동
+3. AI Providers에서 원하는 CLI 도구를 활성화:
+   - **Claude Code (CLI)** - Anthropic Claude Code
+   - **Codex CLI (OpenAI)** - OpenAI Codex CLI
+   - **Gemini CLI (Google)** - Google Gemini CLI
+
+## API Endpoints
+
+### GET /health
+서버 상태 및 사용 가능한 도구 확인
+
+```bash
+curl http://localhost:19284/health
+```
+
+### GET /tools
+사용 가능한 CLI 도구 목록
+
+```bash
+curl http://localhost:19284/tools
+```
+
+### POST /generate
+텍스트 생성 요청
+
+```bash
+curl -X POST http://localhost:19284/generate \
+  -H "Content-Type: application/json" \
+  -d '{"tool": "claude", "prompt": "Hello, world!"}'
+```
+
+## 환경 변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `PORT` | `19284` | 서버 포트 |
+
+## 문제 해결
+
+### "Tool not found" 오류
+해당 CLI 도구가 설치되어 있고 PATH에 있는지 확인하세요.
+
+```bash
+# Claude Code 설치 확인
+claude --version
+
+# Codex CLI 설치 확인
+codex --version
+
+# Gemini CLI 설치 확인
+gemini --version
+```
+
+### 서버 연결 실패
+프록시 서버가 실행 중인지 확인하세요.
+
+```bash
+curl http://localhost:19284/health
+```

--- a/cli-proxy/package.json
+++ b/cli-proxy/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ivlyrics-cli-proxy",
+  "version": "1.0.0",
+  "description": "Local proxy server for CLI AI tools (Antigravity, Claude Code, Codex CLI)",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js --dev"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/cli-proxy/server.js
+++ b/cli-proxy/server.js
@@ -1,0 +1,284 @@
+/**
+ * ivLyrics CLI Proxy Server
+ * CLI AI 도구들 (Antigravity, Claude Code, Codex CLI 등)을 HTTP API로 제공
+ *
+ * 사용법:
+ *   npm install
+ *   npm start
+ *
+ * 기본 포트: 19284
+ */
+
+const express = require('express');
+const cors = require('cors');
+const { spawn, execSync } = require('child_process');
+const app = express();
+
+const PORT = process.env.PORT || 19284;
+
+app.use(cors());
+app.use(express.json({ limit: '10mb' }));
+
+// ============================================
+// CLI Tool Configurations
+// ============================================
+
+const CLI_TOOLS = {
+    // Anthropic Claude Code
+    claude: {
+        command: 'claude',
+        checkCommand: 'claude --version',
+        defaultModel: 'claude-sonnet-4-5-20250514',
+        buildArgs: (prompt, model, defaultModel) => {
+            const useModel = model || defaultModel;
+            const args = ['--print', '--dangerously-skip-permissions', prompt];
+            if (useModel) args.unshift('--model', useModel);
+            return args;
+        },
+        parseOutput: (stdout) => stdout.trim()
+    },
+
+    // OpenAI Codex CLI
+    codex: {
+        command: 'codex',
+        checkCommand: 'codex --version',
+        defaultModel: '',
+        buildArgs: (prompt, model, defaultModel) => {
+            const useModel = model || defaultModel;
+            const args = ['exec', '--skip-git-repo-check', prompt];
+            if (useModel) args.unshift('--config', `model="${useModel}"`);
+            return args;
+        },
+        parseOutput: (stdout) => stdout.trim()
+    },
+
+    // Gemini CLI
+    gemini: {
+        command: 'gemini',
+        checkCommand: 'gemini --version',
+        defaultModel: 'gemini-3-flash-preview',
+        buildArgs: (prompt, model, defaultModel) => {
+            const useModel = model || defaultModel;
+            const args = ['-p', prompt];  // -p 플래그로 non-interactive 모드
+            if (useModel) args.unshift('--model', useModel);
+            return args;
+        },
+        parseOutput: (stdout) => stdout.trim()
+    }
+};
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * CLI 도구 사용 가능 여부 확인
+ */
+function checkToolAvailable(toolId) {
+    const tool = CLI_TOOLS[toolId];
+    if (!tool) return { available: false, error: 'Unknown tool' };
+
+    try {
+        execSync(tool.checkCommand, { stdio: 'pipe', timeout: 5000 });
+        return { available: true };
+    } catch (e) {
+        return { available: false, error: `${tool.command} not found or not configured` };
+    }
+}
+
+/**
+ * CLI 도구 실행
+ */
+function runCLI(toolId, prompt, model = '', timeout = 120000) {
+    return new Promise((resolve, reject) => {
+        const tool = CLI_TOOLS[toolId];
+        if (!tool) {
+            return reject(new Error(`Unknown tool: ${toolId}`));
+        }
+
+        const args = tool.buildArgs(prompt, model, tool.defaultModel);
+        const actualModel = model || tool.defaultModel || 'default';
+
+        // 전체 명령어 로그 (프롬프트는 축약)
+        const promptPreview = prompt.length > 50 ? prompt.substring(0, 50) + '...' : prompt;
+        const argsForLog = args.map(a => a === prompt ? `"${promptPreview}"` : a);
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`[${toolId}] REQUEST`);
+        console.log(`  Model: ${actualModel}`);
+        console.log(`  Command: ${tool.command} ${argsForLog.join(' ')}`);
+        console.log(`${'='.repeat(60)}`);
+
+        const proc = spawn(tool.command, args, {
+            stdio: ['ignore', 'pipe', 'pipe'],  // stdin을 ignore로 설정
+            env: { ...process.env, NO_COLOR: '1' }  // 색상 코드 비활성화
+        });
+
+        let stdout = '';
+        let stderr = '';
+
+        proc.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        proc.stderr.on('data', (data) => {
+            stderr += data.toString();
+        });
+
+        proc.on('close', (code) => {
+            if (code === 0) {
+                const result = tool.parseOutput(stdout);
+                console.log(`[${toolId}] SUCCESS - Response length: ${result.length} chars`);
+                resolve(result);
+            } else {
+                console.log(`[${toolId}] FAILED - Exit code: ${code}`);
+                reject(new Error(stderr || `Process exited with code ${code}`));
+            }
+        });
+
+        proc.on('error', (err) => {
+            reject(new Error(`Failed to start ${tool.command}: ${err.message}`));
+        });
+
+        // Timeout
+        setTimeout(() => {
+            proc.kill();
+            reject(new Error(`Timeout after ${timeout}ms`));
+        }, timeout);
+    });
+}
+
+// ============================================
+// API Endpoints
+// ============================================
+
+/**
+ * 헬스 체크 & 사용 가능한 도구 목록
+ */
+app.get('/health', (req, res) => {
+    const tools = {};
+    for (const toolId of Object.keys(CLI_TOOLS)) {
+        tools[toolId] = checkToolAvailable(toolId);
+    }
+
+    res.json({
+        status: 'ok',
+        version: '1.0.0',
+        tools
+    });
+});
+
+/**
+ * 사용 가능한 도구 목록
+ */
+app.get('/tools', (req, res) => {
+    const tools = [];
+    for (const toolId of Object.keys(CLI_TOOLS)) {
+        const status = checkToolAvailable(toolId);
+        tools.push({
+            id: toolId,
+            name: CLI_TOOLS[toolId].command,
+            available: status.available,
+            error: status.error
+        });
+    }
+    res.json({ tools });
+});
+
+/**
+ * 특정 도구로 프롬프트 실행
+ */
+app.post('/generate', async (req, res) => {
+    const { tool, model, prompt, timeout } = req.body;
+
+    if (!tool || !prompt) {
+        return res.status(400).json({ error: 'Missing tool or prompt' });
+    }
+
+    // 도구 사용 가능 여부 확인
+    const toolStatus = checkToolAvailable(tool);
+    if (!toolStatus.available) {
+        return res.status(400).json({ error: toolStatus.error });
+    }
+
+    try {
+        console.log(`[API] Generate request - tool: ${tool}, model: ${model || 'default'}, prompt length: ${prompt.length}`);
+        const result = await runCLI(tool, prompt, model || '', timeout || 120000);
+        res.json({
+            success: true,
+            result,
+            tool,
+            model: model || 'default'
+        });
+    } catch (e) {
+        console.error(`[API] Error:`, e.message);
+        res.status(500).json({ error: e.message });
+    }
+});
+
+/**
+ * OpenAI API 호환 엔드포인트 (선택적)
+ */
+app.post('/v1/chat/completions', async (req, res) => {
+    const { model, messages } = req.body;
+
+    // model을 tool로 매핑 (예: "antigravity", "claude", "codex")
+    const tool = model?.split('/')[0] || 'claude';
+
+    // 마지막 user 메시지 추출
+    const lastUserMessage = messages?.filter(m => m.role === 'user').pop();
+    const prompt = lastUserMessage?.content || '';
+
+    if (!prompt) {
+        return res.status(400).json({ error: 'No prompt provided' });
+    }
+
+    try {
+        const result = await runCLI(tool, prompt);
+
+        // OpenAI API 형식으로 응답
+        res.json({
+            id: `cli-${Date.now()}`,
+            object: 'chat.completion',
+            created: Math.floor(Date.now() / 1000),
+            model: tool,
+            choices: [{
+                index: 0,
+                message: {
+                    role: 'assistant',
+                    content: result
+                },
+                finish_reason: 'stop'
+            }],
+            usage: {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0
+            }
+        });
+    } catch (e) {
+        res.status(500).json({ error: { message: e.message } });
+    }
+});
+
+// ============================================
+// Start Server
+// ============================================
+
+app.listen(PORT, () => {
+    console.log(`\n🚀 ivLyrics CLI Proxy Server`);
+    console.log(`   Running on http://localhost:${PORT}`);
+    console.log(`\n📋 Available endpoints:`);
+    console.log(`   GET  /health   - Check server status and available tools`);
+    console.log(`   GET  /tools    - List available CLI tools`);
+    console.log(`   POST /generate - Generate text with a CLI tool`);
+    console.log(`   POST /v1/chat/completions - OpenAI-compatible endpoint`);
+    console.log(`\n🔧 Checking available tools...`);
+
+    for (const toolId of Object.keys(CLI_TOOLS)) {
+        const status = checkToolAvailable(toolId);
+        const icon = status.available ? '✓' : '✗';
+        console.log(`   ${icon} ${toolId}: ${status.available ? 'available' : status.error}`);
+    }
+
+    console.log(`\n`);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -55,6 +55,9 @@
 	"subfiles_extension": [
 		"Addon_AI_ChatGPT.js",
 		"Addon_AI_Claude.js",
+		"Addon_AI_CLI_ClaudeCode.js",
+		"Addon_AI_CLI_CodexCLI.js",
+		"Addon_AI_CLI_GeminiCLI.js",
 		"Addon_AI_Gemini.js",
 		"Addon_AI_Groq.js",
 		"Addon_AI_OpenRouter.js",


### PR DESCRIPTION
## Summary
- Add support for local CLI AI tools through a proxy server
- New providers: **Claude Code (CLI)**, **Codex CLI (OpenAI)**, **Gemini CLI (Google)**
- Users with AI subscriptions can use their CLI tools for lyrics translation without separate API keys

## New Files
- `Addon_AI_CLI_ClaudeCode.js` - Anthropic Claude Code provider
- `Addon_AI_CLI_CodexCLI.js` - OpenAI Codex CLI provider
- `Addon_AI_CLI_GeminiCLI.js` - Google Gemini CLI provider
- `cli-proxy/` - Node.js proxy server to bridge CLI tools to HTTP API

## How it works
1. User runs the cli-proxy server locally (`cd cli-proxy && npm install && npm start`)
2. The proxy server listens on `http://localhost:19284`
3. ivLyrics addon sends translation requests to the proxy
4. Proxy executes the CLI tool and returns the response

## Supported CLI Tools
| Tool | Provider | Subscription Required |
|------|----------|----------------------|
| Claude Code | Anthropic | Claude Pro/Max |
| Codex CLI | OpenAI | ChatGPT Pro |
| Gemini CLI | Google | Google AI Pro/Ultra |

## Test plan
- [ ] Install cli-proxy dependencies and start server
- [ ] Enable one of the CLI providers in ivLyrics settings
- [ ] Test lyrics translation with each provider

🤖 Generated with [Claude Code](https://claude.ai/code)