### PR TITLE
fix(chatgpt): prepend http protocol to custom base URL if missing

### DIFF
--- a/Addon_AI_ChatGPT.js
+++ b/Addon_AI_ChatGPT.js
@@ -48,7 +48,11 @@
     async function fetchAvailableModels(apiKey, baseUrl) {
         if (!apiKey) return [];
 
-        const normalizedBaseUrl = (baseUrl || 'https://api.openai.com/v1').replace(/\/$/, '');
+        let trimmedBaseUrl = (baseUrl || 'https://api.openai.com/v1').trim();
+        if (trimmedBaseUrl && !/^https?:\/\//i.test(trimmedBaseUrl)) {
+            trimmedBaseUrl = 'http://' + trimmedBaseUrl;
+        }
+        const normalizedBaseUrl = trimmedBaseUrl.replace(/\/$/, '');
         const isOpenAIBaseUrl = normalizedBaseUrl === 'https://api.openai.com/v1';
 
         // 제외할 모델 패턴 (이미지 생성, 음성, 임베딩 등)
@@ -245,7 +249,12 @@
     }
 
     function getBaseUrl() {
-        return getSetting('base-url', 'https://api.openai.com/v1') || 'https://api.openai.com/v1';
+        let baseUrl = getSetting('base-url', 'https://api.openai.com/v1') || 'https://api.openai.com/v1';
+        baseUrl = baseUrl.trim();
+        if (baseUrl && !/^https?:\/\//i.test(baseUrl)) {
+            baseUrl = 'http://' + baseUrl;
+        }
+        return baseUrl;
     }
 
     function getSelectedModel() {


### PR DESCRIPTION
### Description
When users configure an OpenAI-compatible local API server (e.g., `localhost:8317/v1`) without a protocol scheme (`http://` or `https://`), Spotify's browser shell handles it as a relative path. This causes the fetch request to fail and returns "No models found".

This PR automatically prepends `http://` to the custom Base URL in `Addon_AI_ChatGPT.js` if the URL scheme is missing, ensuring the connection completes successfully.

### Changes
- Trim and prepend `http://` to `baseUrl` in `fetchAvailableModels` and `getBaseUrl` if it doesn't match `http://` or `https://`.