### PR TITLE
fix: score language detection by evidence instead of check order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,4 @@ __pycache__/
 # Local test harnesses
 **/test/
 **/tests/*
-!tests/paxsenix-entity-decoding.test.js
-!tests/windows-updater-paths.test.ps1
-!tests/windows-spicetify-utf8-wrapper.test.js
+!tests/language-detection.test.js

--- a/LyricsService.js
+++ b/LyricsService.js
@@ -435,26 +435,22 @@
                 return String(line || "");
             };
 
-            let cacheKey = "";
-            for (const line of lyrics) {
-                const text = extractTextSafely(line);
-                if (!text) continue;
-                cacheKey = cacheKey ? `${cacheKey} ${text}` : text;
-                if (cacheKey.length >= 200) {
-                    cacheKey = cacheKey.substring(0, 200);
-                    break;
-                }
-            }
-            if (!cacheKey) {
+            // extractTextSafely can hand back a non-string when a line carries
+            // an unexpected shape, so coerce before anything iterates it.
+            const extractLineText = (line) => String(extractTextSafely(line) ?? "");
+
+            const rawLyrics = lyrics.map(extractLineText).join(" ");
+            if (!rawLyrics.trim()) {
                 return null;
-            }
-            if (this._langDetectCache.has(cacheKey)) {
-                return this._langDetectCache.get(cacheKey);
             }
 
-            const rawLyrics = lyrics.map(extractTextSafely).join(" ");
-            if (!rawLyrics || rawLyrics.length === 0) {
-                return null;
+            // Keyed on the whole lyric rather than on its opening 200
+            // characters. Two songs that share an opening -- a repeated intro,
+            // a long instrumental tag, the same sampled hook -- were served
+            // each other's cached verdict.
+            const cacheKey = getLyricsTextCacheHash(rawLyrics);
+            if (this._langDetectCache.has(cacheKey)) {
+                return this._langDetectCache.get(cacheKey);
             }
 
             // Language detection regex patterns
@@ -468,7 +464,6 @@
             const simpRegex = /[万与丑专业丛东丝丢两严丧个丬丰临为丽举么义乌乐乔习乡书买乱争于亏云亘亚产亩亲亵亸亿仅从仑仓仪们价众优伙会伛伞伟传伤伥伦伧伪伫体余佣佥侠侣侥侦侧侨侩侪侬俣俦俨俩俪俭债倾偬偻偾偿傥傧储傩儿兑兖党兰关兴兹养兽冁内冈册写军农冢冯冲决况冻净凄凉凌减凑凛几凤凫凭凯击凼凿刍划刘则刚创删别刬刭刽刿剀剂剐剑剥剧劝办务劢动励劲劳势勋勐勚匀匦匮区医华协单卖卢卤卧卫却卺厂厅历厉压厌厍厕厢厣厦厨厩厮县参叆叇双发变叙叠叶号叹叽吁后吓吕吗吣吨听启吴呒呓呕呖呗员呙呛呜咏咔咙咛咝咤咴咸哌响哑哒哓哔哕哗哙哜哝哟唛唝唠唡唢唣唤唿啧啬啭啮啰啴啸喷喽喾嗫呵嗳嘘嘤嘱噜噼嚣嚯团园囱围囵国图圆圣圹场坂坏块坚坛坜坝坞坟坠垄垅垆垒垦垧垩垫垭垯垱垲垴埘埙埚埝埯堑堕塆墙壮声壳壶壸处备复够头夸夹夺奁奂奋奖奥妆妇妈妩妪妫姗姜娄娅娆娇娈娱娲娴婳婴婵婶媪嫒嫔嫱嬷孙学孪宁宝实宠审宪宫宽宾寝对寻导寿将尔尘尧尴尸尽层屃屉届属屡屦屿岁岂岖岗岘岙岚岛岭岳岽岿峃峄峡峣峤峥峦崂崃崄崭嵘嵚嵛嵝嵴巅巩巯币帅师帏帐帘帜带帧帮帱帻帼幂幞干并广庄庆庐庑库应庙庞废庼廪开异弃张弥弪弯弹强归当录彟彦彻径徕御忆忏忧忾怀态怂怃怄怅怆怜总怼怿恋恳恶恸恹恺恻恼恽悦悫悬悭悯惊惧惨惩惫惬惭惮惯愍愠愤愦愿慑慭憷懑懒懔戆戋戏戗战戬户扎扑扦执扩扪扫扬扰抚抛抟抠抡抢护报担拟拢拣拥拦拧拨择挂挚挛挜挝挞挟挠挡挢挣挤挥挦捞损捡换捣据捻掳掴掷掸掺掼揸揽揿搀搁搂搅携摄摅摆摇摈摊撄撑撵撷撸撺擞攒敌敛数斋斓斗斩断无旧时旷旸昙昼昽显晋晒晓晔晕晖暂暧札术朴机杀杂权条来杨杩杰极构枞枢枣枥枧枨枪枫枭柜柠柽栀栅标栈栉栊栋栌栎栏树栖样栾桊桠桡桢档桤桥桦桧桨桩梦梼梾检棂椁椟椠椤椭楼榄榇榈榉槚槛槟槠横樯樱橥橱橹橼檐檩欢欤欧歼殁殇残殒殓殚殡殴毁毂毕毙毡毵氇气氢氩氲汇汉污汤汹沓沟没沣沤沥沦沧沨沩沪沵泞泪泶泷泸泺泻泼泽泾洁洒洼浃浅浆浇浈浉浊测浍济浏浐浑浒浓浔浕涂涌涛涝涞涟涠涡涢涣涤润涧涨涩淀渊渌渍渎渐渑渔渖渗温游湾湿溃溅溆溇滗滚滞滟滠满滢滤滥滦滨滩滪漤潆潇潋潍潜潴澜濑濒灏灭灯灵灾灿炀炉炖炜炝点炼炽烁烂烃烛烟烦烧烨烩烫烬热焕焖焘煅煳熘爱爷牍牦牵牺犊犟状犷犸犹狈狍狝狞独狭狮狯狰狱狲猃猎猕猡猪猫猬献獭玑玙玚玛玮环现玱玺珉珏珐珑珰珲琎琏琐琼瑶瑷璇璎瓒瓮瓯电画畅畲畴疖疗疟疠疡疬疮疯疱疴痈痉痒痖痨痪痫痴瘅瘆瘗瘘瘪瘫瘾瘿癞癣癫癯皑皱皲盏盐监盖盗盘眍眦眬着睁睐睑瞒瞩矫矶矾矿砀码砖砗砚砜砺砻砾础硁硅硕硖硗硙硚确硷碍碛碜碱碹磙礼祎祢祯祷祸禀禄禅离秃秆种积称秽秾稆税稣稳穑穷窃窍窑窜窝窥窦窭竖竞笃笋笔笕笺笼笾筑筚筛筜筝筹签简箓箦箧箨箩箪箫篑篓篮篱簖籁籴类籼粜粝粤粪粮糁糇紧絷纟纠纡红纣纤纥约级纨纩纪纫纬纭纮纯纰纱纲纳纴纵纶纷纸纹纺纻纼纽纾线绀绁绂练组绅细织终绉绊绋绌绍绎经绐绑绒结绔绕绖绗绘给绚绛络绝绞统绠绡绢绣绤绥绦继绨绩绪绫绬续绮绯绰绱绲绳维绵绶绷绸绹绺绻综绽绾绿缀缁缂缃缄缅缆缇缈缉缊缋缌缍缎缏缐缑缒缓缔缕编缗缘缙缚缛缜缝缞缟缠缡缢缣缤缥缦缧缨缩缪缫缬缭缮缯缰缱缲缳缴缵罂网罗罚罢罴羁羟羡翘翙翚耢耧耸耻聂聋职聍联聵聽聰肅腸膚膁腎腫脹脅膽勝朧腖臚脛膠脈膾髒臍腦膿臠腳脫腡臉臘醃膕齶膩靦膃騰臏臢輿艤艦艙艫艱豔艸藝節羋薌蕪蘆蓯葦藶莧萇蒼苧蘇檾蘋莖蘢蔦塋煢繭荊薦薘莢蕘蓽蕎薈薺蕩榮葷滎犖熒蕁藎蓀蔭蕒葒葤藥蒞蓧萊蓮蒔萵薟獲蕕瑩鶯蓴蘀蘿螢營縈蕭薩蔥蕆蕢蔣蔞藍薊蘺蕷鎣驀薔蘞藺藹蘄蘊藪槁蘚虜慮虛蟲虯虮雖蝦蠆蝕蟻螞蠶蠔蜆蠱蠣蟶蠻蟄蛺蟯螄蠐蛻蝸蠟蠅蟈蟬蠍螻蠑螿蟎蠨釁銜補襯袞襖嫋褘襪襲襏裝襠褌褳襝褲襇褸襤繈襴見觀覎規覓視覘覽覺覬覡覿覥覦覯覲覷觴觸觶讋譽謄訁計訂訃認譏訐訌討讓訕訖訓議訊記訒講諱謳詎訝訥許訛論訩訟諷設訪訣證詁訶評詛識詗詐訴診詆謅詞詘詔詖譯詒誆誄試詿詩詰詼誠誅詵話誕詬詮詭詢詣諍該詳詫諢詡譸誡誣語誚誤誥誘誨誑說誦誒請諸諏諾讀諑誹課諉諛誰諗調諂諒諄誶談誼謀諶諜謊諫諧謔謁謂諤諭諼讒諮諳諺諦謎諞諝謨讜謖謝謠謗諡謙謐謹謾謫譾謬譚譖譙讕譜譎讞譴譫讖穀豶貝貞負貟貢財責賢敗賬貨質販貪貧貶購貯貫貳賤賁貰貼貴貺貸貿費賀貽賊贄賈賄貲賃賂贓資賅贐賕賑賚賒賦賭齎贖賞賜贔賙賡賠賧賴賵贅賻賺賽賾贗讚贇贈贍贏贛赬趙趕趨趲躉躍蹌蹠躒踐躂蹺蹕躚躋踴躊蹤躓躑躡蹣躕躥躪躦軀車軋軌軑軔轉軛輪軟轟軲軻轤軸軹軼軤軫轢軺輕軾載輊轎輈輇輅較輒輔輛輦輩輝輥輞輬輟輜輳輻輯轀輸轡轅轄輾轆轍轔辯辮邊遼達遷過邁運還這進遠違連遲邇逕跡適選遜遞邐邏遺遙鄧鄺鄔郵鄒鄴鄰鬱郤郟鄶鄭鄆酈鄖鄲醞醱醬釅釃釀釋裏钜鑒鑾鏨釓釔針釘釗釙釕釷釺釧釤鈒釩釣鍆釹鍚釵鈃鈣鈈鈦鈍鈔鍾鈉鋇鋼鈑鈐鑰欽鈞鎢鉤鈧鈁鈥鈄鈕鈀鈺錢鉦鉗鈷缽鈳鉕鈽鈸鉞鑽鉬鉭鉀鈿鈾鐵鉑鈴鑠鉛鉚鈰鉉鉈鉍鈹鐸鉶銬銠鉺銪鋏鋣鐃銍鐺銅鋁銱銦鎧鍘銖銑鋌銩銛鏵銓鉿銚鉻銘錚銫鉸銥鏟銃鐋銨銀銣鑄鐒鋪鋙錸鋱鏈鏗銷鎖鋰鋥鋤鍋鋯鋨鏽銼鋝鋒鋅鋶鐦鐧銳銻鋃鋟鋦錒錆鍺錯錨錡錁錕錩錫錮鑼錘錐錦鍁錈錇錟錠鍵鋸錳錙鍥鍈鍇鏘鍶鍔鍤鍬鍾鍛鎪鍠鍰鎄鍍鎂鏤鎡鏌鎮鎛鎘鑷鐫鎳鎿鎦鎬鎊鎰鎔鏢鏜鏍鏰鏞鏡鏑鏃鏇鏐鐔钁鐐鏷鑥鐓鑭鐠鑹鏹鐙鑊鐳鐶鐲鐮鐿鑔鑣鑞鑲長門閂閃閆閈閉問闖閏闈閑閎間閔閌悶閘鬧閨聞闼閩閭闓閥閣閡閫鬮閱閬闍閾閹閶鬩閿閽閻閼闡闌闃闠闊闋闔闐闒闕闞闤隊陽陰陣階際陸隴陳陘陝隉隕險隨隱隸雋難雛讎靂霧霽黴靄靚靜靨韃鞽韉韝韋韌韍韓韙韞韜韻页顶顷顸项顺须顼顽顾顿颀颁颂颃预颅领颇颈颉颊颋颌颍颎颏颐频颒颓颔颕颖颗题颙颚颛颜额颞颟颠颡颢颣颤颥颦颧风飏飐飑飒飓飔飕飖飗飘飙飚飞飨餍饤饥饦饧饨饩饪饫饬饭饮饯饰饱饲饳饴饵饶饷饸饹饺饻饼饽饾饿馀馁馂馃馄馅馆馇馈馉馊馋馌馍馎馏馐馑馒馓馔馕马驭驮驯驰驱驲驳驴驵驶驷驸驹驺驻驼驽驾驿骀骁骂骃骄骅骆骇骈骉骊骋验骍骎骏骐骑骒骓骔骕骖骗骘骙骚骛骜骝骞骟骠骡骢骣骤骥骦骧髅髋髌鬓魇魉鱼鱽鱾鱿鲀鲁鲂鲄鲅鲆鲇鲈鲉鲊鲋鲌鲍鲎鲏鲐鲑鲒鲓鲔鲕鲖鲗鲘鲙鲚鲛鲜鲝鲞鲟鲠鲡鲢鲣鲤鲥鲦鲧鲨鲩鲪鲫鲬鲭鲮鲯鲰鲱鲲鲳鲴鲵鲶鲷鲸鲹鲺鲻鲼鲽鲾鲿鳀鳁鳂鳃鳄鳅鳆鳇鳈鳉鳊鳋鳌鳍鳎鳏鳐鳑鳒鳓鳔鳕鳖鳗鳘鳙鳛鳜鳝鳞鳟鳠鳡鳢鳣鸟鸠鸡鸢鸣鸤鸥鸦鸧鸨鸩鸪鸫鸬鸭鸮鸯鸰鸱鸲鸳鸴鸵鸶鸷鸸鸹鸺鸻鸼鸽鸾鸿鹀鹁鹂鹃鹄鹅鹆鹇鹈鹉鹊鹋鹌鹍鹎鹏鹐鹑鹒鹓鹔鹕鹖鹗鹘鹚鹛鹜鹝鹞鹟鹠鹡鹢鹣鹤鹥鹦鹧鹨鹩鹪鹫鹬鹭鹯鹰鹱鹲鹳鹴鹾麦麸黄黉黡黩黪黾鼋鼌鼍鼗鼹齄齐齑齿龀龁龂龃龄龅龆龇龈龉龊龋龌龙龚龛龟志制咨只里系范松没尝尝闹面准钟别闲干尽脏拼]/gu;
             const tradRegex = /[萬與醜專業叢東絲丟兩嚴喪個爿豐臨為麗舉麼義烏樂喬習鄉書買亂爭於虧雲亙亞產畝親褻嚲億僅從侖倉儀們價眾優夥會傴傘偉傳傷倀倫傖偽佇體餘傭僉俠侶僥偵側僑儈儕儂俁儔儼倆儷儉債傾傯僂僨償儻儐儲儺兒兌兗黨蘭關興茲養獸囅內岡冊寫軍農塚馮衝決況凍淨淒涼淩減湊凜幾鳳鳧憑凱擊氹鑿芻劃劉則剛創刪別剗剄劊劌剴劑剮劍剝劇勸辦務勱動勵勁勞勣勳猛勩勻匭匱區醫華協單賣盧鹵臥衛卻巹廠廳曆厲壓厭厙廁廂厴廈廚廄廝縣參靉靆雙發變敘疊葉號歎嘰籲後嚇呂嗎唚噸聽啟吳嘸囈嘔嚦唄員咼嗆嗚詠哢嚨嚀噝吒噅鹹呱響啞噠嘵嗶噦嘩噲嚌噥喲嘜嗊嘮啢嗩唕喚呼嘖嗇囀齧囉嘽嘯噴嘍嚳囁嗬噯噓嚶囑嚕劈囂謔團園囪圍圇國圖圓聖壙場阪壞塊堅壇壢壩塢墳墜壟壟壚壘墾坰堊墊埡墶壋塏堖塒塤堝墊垵塹墮壪牆壯聲殼壺壼處備複夠頭誇夾奪奩奐奮獎奧妝婦媽嫵嫗媯姍薑婁婭嬈嬌孌娛媧嫻嫿嬰嬋嬸媼嬡嬪嬙嬤孫學孿寧寶實寵審憲宮寬賓寢對尋導壽將爾塵堯尷屍盡層屭屜屆屬屢屨嶼歲豈嶇崗峴嶴嵐島嶺嶽崠巋嶨嶧峽嶢嶠崢巒嶗崍嶮嶄嶸嶔崳嶁脊巔鞏巰幣帥師幃帳簾幟帶幀幫幬幘幗冪襆幹並廣莊慶廬廡庫應廟龐廢廎廩開異棄張彌弳彎彈強歸當錄彠彥徹徑徠禦憶懺憂愾懷態慫憮慪悵愴憐總懟懌戀懇惡慟懨愷惻惱惲悅愨懸慳憫驚懼慘懲憊愜慚憚慣湣慍憤憒願懾憖怵懣懶懍戇戔戲戧戰戬戶紮撲扡執擴捫掃揚擾撫拋摶摳掄搶護報擔擬攏揀擁攔擰撥擇掛摯攣掗撾撻挾撓擋撟掙擠揮撏撈損撿換搗據撚擄摑擲撣摻摜摣攬撳攙擱摟攪攜攝攄擺搖擯攤攖撐攆擷擼攛擻攢敵斂數齋斕鬥斬斷無舊時曠暘曇晝曨顯晉曬曉曄暈暉暫曖劄術樸機殺雜權條來楊榪傑極構樅樞棗櫪梘棖槍楓梟櫃檸檉梔柵標棧櫛櫳棟櫨櫟欄樹棲樣欒棬椏橈楨檔榿橋樺檜槳樁夢檮棶檢欞槨櫝槧欏橢樓欖櫬櫚櫸檟檻檳櫧橫檣櫻櫫櫥櫓櫞簷檁歡歟歐殲歿殤殘殞殮殫殯毆毀轂畢斃氈毿氌氣氫氬氲彙漢汙湯洶遝溝沒灃漚瀝淪滄渢溈滬濔濘淚澩瀧瀘濼瀉潑澤涇潔灑窪浹淺漿澆湞溮濁測澮濟瀏滻渾滸濃潯濜塗湧濤澇淶漣潿渦溳渙滌潤澗漲澀澱淵淥漬瀆漸澠漁瀋滲溫遊灣濕潰濺漵漊潷滾滯灩灄滿瀅濾濫灤濱灘澦濫瀠瀟瀲濰潛瀦瀾瀨瀕灝滅燈靈災燦煬爐燉煒熗點煉熾爍爛烴燭煙煩燒燁燴燙燼熱煥燜燾煆糊溜愛爺牘犛牽犧犢強狀獷獁猶狽麅獮獰獨狹獅獪猙獄猻獫獵獼玀豬貓蝟獻獺璣璵瑒瑪瑋環現瑲璽瑉玨琺瓏璫琿璡璉瑣瓊瑤璦璿瓔瓚甕甌電畫暢佘疇癤療瘧癘瘍鬁瘡瘋皰屙癰痙癢瘂癆瘓癇癡癉瘮瘞瘺癟癱癮癭癩癬癲臒皚皺皸盞鹽監蓋盜盤瞘眥矓著睜睞瞼瞞矚矯磯礬礦碭碼磚硨硯碸礪礱礫礎硜矽碩硤磽磑礄確鹼礙磧磣堿镟滾禮禕禰禎禱禍稟祿禪離禿稈種積稱穢穠穭稅穌穩穡窮竊竅窯竄窩窺竇窶豎競篤筍筆筧箋籠籩築篳篩簹箏籌簽簡籙簀篋籜籮簞簫簣簍籃籬籪籟糴類秈糶糲粵糞糧糝餱緊縶糸糾紆紅紂纖紇約級紈纊紀紉緯紜紘純紕紗綱納紝縱綸紛紙紋紡紵紖紐紓線紺絏紱練組紳細織終縐絆紼絀紹繹經紿綁絨結絝繞絰絎繪給絢絳絡絕絞統綆綃絹繡綌綏絛繼綈績緒綾緓續綺緋綽緔緄繩維綿綬繃綢綯綹綣綜綻綰綠綴緇緙緗緘緬纜緹緲緝縕繢緦綞緞緶線緱縋緩締縷編緡緣縉縛縟縝縫縗縞纏縭縊縑繽縹縵縲纓縮繆繅纈繚繕繒韁繾繰繯繳纘罌網羅罰罷羆羈羥羨翹翽翬耮耬聳恥聶聾職聹聯聵聽聰肅腸膚膁腎腫脹脅膽勝朧腖臚脛膠脈膾髒臍腦膿臠腳脫腡臉臘醃膕齶膩靦膃騰臏臢輿艤艦艙艫艱豔艸藝節羋薌蕪蘆蓯葦藶莧萇蒼苧蘇檾蘋莖蘢蔦塋煢繭荊薦薘莢蕘蓽蕎薈薺蕩榮葷滎犖熒蕁藎蓀蔭蕒葒葤藥蒞蓧萊蓮蒔萵薟獲蕕瑩鶯蓴蘀蘿螢營縈蕭薩蔥蕆蕢蔣蔞藍薊蘺蕷鎣驀薔蘞藺藹蘄蘊藪槁蘚虜慮虛蟲虯虮雖蝦蠆蝕蟻螞蠶蠔蜆蠱蠣蟶蠻蟄蛺蟯螄蠐蛻蝸蠟蠅蟈蟬蠍螻蠑螿蟎蠨釁銜補襯袞襖嫋褘襪襲襏裝襠褌褳襝褲襇褸襤繈襴見觀覎規覓視覘覽覺覬覡覿覥覦覯覲覷觴觸觶讋譽謄訁計訂訃認譏訐訌討讓訕訖訓議訊記訒講諱謳詎訝訥許訛論訩訟諷設訪訣證詁訶評詛識詗詐訴診詆謅詞詘詔詖譯詒誆誄試詿詩詰詼誠誅詵話誕詬詮詭詢詣諍該詳詫諢詡譸誡誣語誚誤誥誘誨誑說誦誒請諸諏諾讀諑誹課諉諛誰諗調諂諒諄誶談誼謀諶諜謊諫諧謔謁謂諤諭諼讒諮諳諺諦謎諞諝謨讜謖謝謠謗諡謙謐謹謾謫譾謬譚譖譙讕譜譎讞譴譫讖穀豶貝貞負貟貢財責賢敗賬貨質販貪貧貶購貯貫貳賤賁貰貼貴貺貸貿費賀貽賊贄賈賄貲賃賂贓資賅贐賕賑賚賒賦賭齎贖賞賜贔賙賡賠賧賴賵贅賻賺賽賾贗讚贇贈贍贏贛赬趙趕趨趲躉躍蹌蹠躒踐躂蹺蹕躚躋踴躊蹤躓躑躡蹣躕躥躪躦軀車軋軌軑軔轉軛輪軟轟軲軻轤軸軹軼軤軫轢軺輕軾載輊轎輈輇輅較輒輔輛輦輩輝輥輞輬輟輜輳輻輯轀輸轡轅轄輾轆轍轔辯辮邊遼達遷過邁運還這進遠違連遲邇逕跡適選遜遞邐邏遺遙鄧鄺鄔郵鄒鄴鄰鬱郤郟鄶鄭鄆酈鄖鄲醞醱醬釅釃釀釋裏钜鑒鑾鏨釓釔針釘釗釙釕釷釺釧釤鈒釩釣鍆釹鍚釵鈃鈣鈈鈦鈍鈔鍾鈉鋇鋼鈑鈐鑰欽鈞鎢鉤鈧鈁鈥鈄鈕鈀鈺錢鉦鉗鈷缽鈳鉕鈽鈸鉞鑽鉬鉭鉀鈿鈾鐵鉑鈴鑠鉛鉚鈰鉉鉈鉍鈹鐸鉶銬銠鉺銪鋏鋣鐃銍鐺銅鋁銱銦鎧鍘銖銑鋌銩銛鏵銓鉿銚鉻銘錚銫鉸銥鏟銃鐋銨銀銣鑄鐒鋪鋙錸鋱鏈鏗銷鎖鋰鋥鋤鍋鋯鋨鏽銼鋝鋒鋅鋶鐦鐧銳銻鋃鋟鋦錒錆鍺錯錨錡錁錕錩錫錮鑼錘錐錦鍁錈錇錟錠鍵鋸錳錙鍥鍈鍇鏘鍶鍔鍤鍬鍾鍛鎪鍠鍰鎄鍍鎂鏤鎡鏌鎮鎛鎘鑷鐫鎳鎿鎦鎬鎊鎰鎔鏢鏜鏍鏰鏞鏡鏑鏃鏇鏐鐔钁鐐鏷鑥鐓鑭鐠鑹鏹鐙鑊鐳鐶鐲鐮鐿鑔鑣鑞鑲長門閂閃閆閈閉問闖閏闈閑閎間閔閌悶閘鬧閨聞闼閩閭闓閥閣閡閫鬮閱閬闍閾閹閶鬩閿閽閻閼闡闌闃闠闊闋闔闐闒闕闞闤隊陽陰陣階際陸隴陳陘陝隉隕險隨隱隸雋難雛讎靂霧霽黴靄靚靜靨韃鞽韉韝韋韌韍韓韙韞韜韻页顶顷顸项顺须顼顽顾顿颀颁颂颃预颅领颇颈颉颊颋颌颍颎颏颐频颒颓颔颕颖颗题颙颚颛颜额颞颟颠颡颢颣颤颥颦颧风飏飐飑飒飓飔飕飖飗飘飙飚飞飨餍饤饥饦饧饨饩饪饫饬饭饮饯饰饱饲饳饴饵饶饷饸饹饺饻饼饽饾饿馀馁馂馃馄馅馆馇馈馉馊馋馌馍馎馏馐馑馒馓馔馕马驭驮驯驰驱驲驳驴驵驶驷驸驹驺驻驼驽驾驿骀骁骂骃骄骅骆骇骈骉骊骋验骍骎骏骐骑骒骓骔骕骖骗骘骙骚骛骜骝骞骟骠骡骢骣骤骥骦骧髅髋髌鬓魇魉鱼鱽鱾鱿鲀鲁鲂鲄鲅鲆鲇鲈鲉鲊鲋鲌鲍鲎鲏鲐鲑鲒鲓鲔鲕鲖鲗鲘鲙鲚鲛鲜鲝鲞鲟鲠鲡鲢鲣鲤鲥鲦鲧鲨鲩鲪鲫鲬鲭鲮鲯鲰鲱鲲鲳鲴鲵鲶鲷鲸鲹鲺鲻鲼鲽鲾鲿鳀鳁鳂鳃鳄鳅鳆鳇鳈鳉鳊鳋鳌鳍鳎鳏鳐鳑鳒鳓鳔鳕鳖鳗鳘鳙鳛鳜鳝鳞鳟鳠鳡鳢鳣鸟鸠鸡鸢鸣鸤鸥鸦鸧鸨鸩鸪鸫鸬鸭鸮鸯鸰鸱鸲鸳鸴鸵鸶鸷鸸鸹鸺鸻鸼鸽鸾鸿鹀鹁鹂鹃鹄鹅鹆鹇鹈鹉鹊鹋鹌鹍鹎鹏鹐鹑鹒鹓鹔鹕鹖鹗鹘鹚鹛鹜鹝鹞鹟鹠鹡鹢鹣鹤鹥鹦鹧鹨鹩鹪鹫鹬鹭鹯鹰鹱鹲鹳鹴鹾麦麸黄黉黡黩黪黾鼋鼌鼍鼗鼹齄齐齑齿龀龁龂龃龄龅龆龇龈龉龊龋龌龙龚龛龟志制咨只里系范松没尝尝闹面准钟别闲干尽脏拼]/gu;
             const hanziRegex = /\p{Script=Han}/gu;
-            const cyrillicRegex = /[\u0400-\u04FF]/gu;
             const vietnameseRegex = /[àáạảãâầấậẩẫăằắặẳẵèéẹẻẽêềếệểễìíịỉĩòóọỏõôồốộổỗơờớợởỡùúụủũưừứựửữỳýỵỷỹđ]/gu;
             const vietnameseUniqueRegex = /[đĐưƯơƠăĂạảẠẢắằẳẵặẮẰẲẴẶấầẩẫậẤẦẨẪẬếềểễệẾỀỂỄỆịỉĨỈỊọỏộốồổỗỌỎỐỒỔỖớờởỡợỚỜỞỠỢụủứừửữựỤỦƯỨỪỬỮỰỵỷỹỲỴỶỸ]/gu;
             const swedishRegex = /[åäöÅÄÖ]/gu;
@@ -488,13 +483,9 @@
             // Persian shares the Arabic block, so it is only separable by the
             // letters Arabic does not use: peh, tcheh, jeh, gaf, keheh, farsi yeh.
             const persianUniqueRegex = /[\u067E\u0686\u0698\u06AF\u06A9\u06CC]/gu;
-            const thaiRegex = /[\u0E00-\u0E7F]/gu;
-            const devanagariRegex = /[\u0900-\u097F]/gu;
-            const bengaliRegex = /[\u0980-\u09FF]/gu;
             const latinExtendedRegex = /\p{Script=Latin}/gu;
             const latinWordRegex = /\p{Script=Latin}+(?:['’]\p{Script=Latin}+)?/gu;
 
-            const cyrillicMatch = rawLyrics.match(cyrillicRegex);
             const vietnameseMatch = rawLyrics.match(vietnameseRegex);
             const vietnameseUniqueMatch = rawLyrics.match(vietnameseUniqueRegex);
             const swedishMatch = rawLyrics.match(swedishRegex);
@@ -512,9 +503,6 @@
             const czechUniqueMatch = rawLyrics.match(czechUniqueRegex);
             const arabicMatch = rawLyrics.match(arabicRegex);
             const persianUniqueMatch = rawLyrics.match(persianUniqueRegex);
-            const thaiMatch = rawLyrics.match(thaiRegex);
-            const hindiMatch = rawLyrics.match(devanagariRegex);
-            const bengaliMatch = rawLyrics.match(bengaliRegex);
             const latinMatch = rawLyrics.match(latinExtendedRegex);
             const normalizedLatinLyrics = rawLyrics.toLowerCase().normalize("NFC");
             const latinWords = normalizedLatinLyrics.match(latinWordRegex) || [];
@@ -675,11 +663,18 @@
                     sv: /[åäö]/u,
                     vi: /[đươăạảấầẩẫậắằẳẵặếềểễệốồổỗộớờởỡợụủứừửữựỳỵỷỹ]/u
                 };
-                // Only applied to running text: the romanized transcriptions
-                // this guards against are full songs, whereas a short phrase
-                // ("te quiero") can be perfectly ordinary Spanish and still
-                // contain no accent at all.
-                if (latinWords.length >= 8) {
+                // Applied only where the word evidence is thin. Genuine lyrics
+                // hit their own function words densely even when an accent
+                // never appears, while a romanized transcription only collects
+                // scattered accidental matches; across the sampled songs the
+                // two populations do not overlap (genuine text bottoms out
+                // around 0.22 hits per word, romanized text peaks near 0.17).
+                // Gating on that keeps the adjustment from overturning a real
+                // majority: four French lines against one German line must stay
+                // French, whatever accents the French happens to carry.
+                const leadingScore = Math.max(...Object.values(scores));
+                const evidenceDensity = leadingScore / (latinWords.length || 1);
+                if (latinWords.length >= 8 && evidenceDensity < 0.2) {
                     Object.entries(diacriticBearing).forEach(([lang, pattern]) => {
                         if (scores[lang] > 0 && !pattern.test(normalizedLatinLyrics)) {
                             scores[lang] = Math.floor(scores[lang] / 2);
@@ -715,18 +710,17 @@
             // early returns in which whichever check ran first won outright: a
             // single foreign glyph in a hook could relabel an entire song, and
             // the raw-count thresholds did not scale with lyric length.
-            const totalScriptChars = (rawLyrics.match(/\S/gu) || []).length || 1;
 
             const hangulCount = (rawLyrics.match(hangulRegex) || []).length;
             const kanaCount = (rawLyrics.match(kanaRegex) || []).length;
             const hanChars = rawLyrics.match(hanziRegex) || [];
             const cjkCharCount = hangulCount + kanaCount + hanChars.length;
 
-            const shareOfText = (count) => count / totalScriptChars;
 
             // A song's actual language covers a meaningful share of the text.
             // A borrowed hook, a loanword or a stray glyph does not.
-            const DOMINANT_SCRIPT_SHARE = 0.12;
+            const NON_LATIN_LINE_SHARE = 0.15;
+            const NON_LATIN_MIN_LINES = 3;
 
             const resolveCjkLanguage = () => {
                 // Korean is the only CJK language that uses Hangul at all.
@@ -747,17 +741,21 @@
                 const simpTestRegex = new RegExp(simpRegex.source, "u");
                 const tradTestRegex = new RegExp(tradRegex.source, "u");
 
+                // The two character classes are not disjoint: more than half of
+                // each also appears in the other. Counting a glyph that matches
+                // both as evidence for both made shared characters look like
+                // distinguishing evidence, which is enough to hold common
+                // traditional text at exactly the simplified threshold. Only
+                // glyphs exclusive to one class carry information here.
                 let simpCount = 0;
                 let tradCount = 0;
                 hanChars.forEach((glyph) => {
-                    if (simpTestRegex.test(glyph)) simpCount++;
-                    if (tradTestRegex.test(glyph)) tradCount++;
+                    const isSimp = simpTestRegex.test(glyph);
+                    const isTrad = tradTestRegex.test(glyph);
+                    if (isSimp && !isTrad) simpCount++;
+                    else if (isTrad && !isSimp) tradCount++;
                 });
 
-                // Simplified and traditional Chinese share most characters, so
-                // the ratio is taken over the glyphs that actually differ. Taken
-                // over every Han character the shared majority dominated and
-                // pulled effectively all Chinese text toward simplified.
                 const distinguishing = simpCount + tradCount;
                 const hansThreshold = Number(Spicetify.LocalStorage.get("ivLyrics:visual:hans-detect-threshold")) || 40;
                 if (distinguishing === 0) {
@@ -768,18 +766,67 @@
                 return ((simpPercentage - tradPercentage + 1) / 2) * 100 >= hansThreshold ? "zh-hans" : "zh-hant";
             };
 
-            const scriptCandidates = [
-                ["cjk", shareOfText(cjkCharCount)],
-                ["ru", shareOfText(cyrillicMatch ? cyrillicMatch.length : 0)],
-                ["ar", shareOfText(arabicMatch ? arabicMatch.length : 0)],
-                ["th", shareOfText(thaiMatch ? thaiMatch.length : 0)],
-                ["hi", shareOfText(hindiMatch ? hindiMatch.length : 0)],
-                ["bn", shareOfText(bengaliMatch ? bengaliMatch.length : 0)]
-            ].sort((left, right) => right[1] - left[1]);
+            // Which script owns the lyric is decided by counting lines, not
+            // characters. Character counts are not comparable across scripts:
+            // a Han or Hangul glyph carries roughly a syllable where a Latin
+            // character carries a letter, so a song can hold fewer CJK
+            // characters than its English hook and still be a Korean song.
+            // Counting lines also means one ordinary line in another language
+            // cannot outvote the rest of the lyric, which a share of total
+            // characters could -- Latin was not among the candidates at all,
+            // so any non-Latin script clearing the bar won outright.
+            // Non-global copies: .test() on a /g/ regex advances lastIndex
+            // between calls and would misclassify every other character.
+            const hanziTestRegex = new RegExp(hanziRegex.source, "u");
+            const latinTestRegex = new RegExp(latinExtendedRegex.source, "u");
 
-            const [dominantScript, dominantShare] = scriptCandidates[0];
+            const scriptOfLine = (text) => {
+                const counts = { latin: 0, cjk: 0, ru: 0, ar: 0, th: 0, hi: 0, bn: 0 };
+                for (const character of text) {
+                    const code = character.codePointAt(0);
+                    if (code >= 0x0980 && code <= 0x09FF) counts.bn++;
+                    else if (code >= 0x0900 && code <= 0x097F) counts.hi++;
+                    else if (code >= 0x0E00 && code <= 0x0E7F) counts.th++;
+                    else if (code >= 0x0600 && code <= 0x06FF) counts.ar++;
+                    else if (code >= 0x0400 && code <= 0x04FF) counts.ru++;
+                    else if (
+                        (code >= 0x1100 && code <= 0x11FF) || (code >= 0x3130 && code <= 0x318F) ||
+                        (code >= 0xAC00 && code <= 0xD7AF) || (code >= 0x3040 && code <= 0x30FF) ||
+                        (code >= 0xFF66 && code <= 0xFF9F) || hanziTestRegex.test(character)
+                    ) counts.cjk++;
+                    else if (latinTestRegex.test(character)) counts.latin++;
+                }
+                const ranked = Object.entries(counts).sort((left, right) => right[1] - left[1]);
+                return ranked[0][1] > 0 ? ranked[0][0] : null;
+            };
 
-            if (dominantShare >= DOMINANT_SCRIPT_SHARE) {
+            const lineVotes = new Map();
+            for (const line of lyrics) {
+                const script = scriptOfLine(extractLineText(line));
+                if (script) lineVotes.set(script, (lineVotes.get(script) || 0) + 1);
+            }
+
+            // A borrowed hook is one or two lines out of many, whereas a song
+            // that genuinely mixes languages carries its own script throughout.
+            // A non-Latin script therefore claims the lyric on holding a large
+            // enough share of the lines, not on holding the most: Korean pop
+            // routinely has more English lines than Korean ones and is still
+            // Korean.
+            const scriptCandidates = [...lineVotes.entries()].sort((left, right) => right[1] - left[1]);
+            const totalLineVotes = [...lineVotes.values()].reduce((sum, n) => sum + n, 0) || 1;
+            const nonLatinCandidates = scriptCandidates.filter(([script]) => script !== "latin");
+            const [dominantScript, dominantVotes] = nonLatinCandidates.length ? nonLatinCandidates[0] : [null, 0];
+
+            // The line floor only makes sense once there are enough lines for
+            // something to be a hook: a one-line fragment in another script is
+            // simply that language, not a borrowed hook in a longer lyric.
+            const hookFloorApplies = totalLineVotes >= 4;
+
+            if (
+                dominantScript &&
+                (!hookFloorApplies || dominantVotes >= NON_LATIN_MIN_LINES) &&
+                (dominantVotes / totalLineVotes) >= NON_LATIN_LINE_SHARE
+            ) {
                 let resolved = dominantScript;
 
                 if (dominantScript === "cjk") {

--- a/LyricsService.js
+++ b/LyricsService.js
@@ -385,7 +385,6 @@
     const Utils = {
         _langDetectCache: new Map(),
         _maxLangCacheSize: 500,
-        _cjkMatchRegex: null,
 
         _cacheLanguageResult(cacheKey, result) {
             if (this._langDetectCache.size >= this._maxLangCacheSize) {
@@ -459,8 +458,13 @@
             }
 
             // Language detection regex patterns
-            const kanaRegex = /[\u3001-\u3003]|[\u3005\u3007]|[\u301d-\u301f]|[\u3021-\u3035]|[\u3038-\u303a]|[\u3040-\u30ff]|[\uff66-\uff9f]/gu;
-            const hangulRegex = /(\S*[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]+\S*)/g;
+            // Character-level so the CJK counts are comparable: the previous
+            // Hangul pattern matched whole words while every other matcher
+            // matched single characters, and the Kana pattern included CJK
+            // punctuation, which inflated the kana-to-han ratio that separates
+            // Japanese from Chinese.
+            const kanaRegex = /[\u3040-\u30FF\uFF66-\uFF9F]/gu;
+            const hangulRegex = /[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7AF]/gu;
             const simpRegex = /[万与丑专业丛东丝丢两严丧个丬丰临为丽举么义乌乐乔习乡书买乱争于亏云亘亚产亩亲亵亸亿仅从仑仓仪们价众优伙会伛伞伟传伤伥伦伧伪伫体余佣佥侠侣侥侦侧侨侩侪侬俣俦俨俩俪俭债倾偬偻偾偿傥傧储傩儿兑兖党兰关兴兹养兽冁内冈册写军农冢冯冲决况冻净凄凉凌减凑凛几凤凫凭凯击凼凿刍划刘则刚创删别刬刭刽刿剀剂剐剑剥剧劝办务劢动励劲劳势勋勐勚匀匦匮区医华协单卖卢卤卧卫却卺厂厅历厉压厌厍厕厢厣厦厨厩厮县参叆叇双发变叙叠叶号叹叽吁后吓吕吗吣吨听启吴呒呓呕呖呗员呙呛呜咏咔咙咛咝咤咴咸哌响哑哒哓哔哕哗哙哜哝哟唛唝唠唡唢唣唤唿啧啬啭啮啰啴啸喷喽喾嗫呵嗳嘘嘤嘱噜噼嚣嚯团园囱围囵国图圆圣圹场坂坏块坚坛坜坝坞坟坠垄垅垆垒垦垧垩垫垭垯垱垲垴埘埙埚埝埯堑堕塆墙壮声壳壶壸处备复够头夸夹夺奁奂奋奖奥妆妇妈妩妪妫姗姜娄娅娆娇娈娱娲娴婳婴婵婶媪嫒嫔嫱嬷孙学孪宁宝实宠审宪宫宽宾寝对寻导寿将尔尘尧尴尸尽层屃屉届属屡屦屿岁岂岖岗岘岙岚岛岭岳岽岿峃峄峡峣峤峥峦崂崃崄崭嵘嵚嵛嵝嵴巅巩巯币帅师帏帐帘帜带帧帮帱帻帼幂幞干并广庄庆庐庑库应庙庞废庼廪开异弃张弥弪弯弹强归当录彟彦彻径徕御忆忏忧忾怀态怂怃怄怅怆怜总怼怿恋恳恶恸恹恺恻恼恽悦悫悬悭悯惊惧惨惩惫惬惭惮惯愍愠愤愦愿慑慭憷懑懒懔戆戋戏戗战戬户扎扑扦执扩扪扫扬扰抚抛抟抠抡抢护报担拟拢拣拥拦拧拨择挂挚挛挜挝挞挟挠挡挢挣挤挥挦捞损捡换捣据捻掳掴掷掸掺掼揸揽揿搀搁搂搅携摄摅摆摇摈摊撄撑撵撷撸撺擞攒敌敛数斋斓斗斩断无旧时旷旸昙昼昽显晋晒晓晔晕晖暂暧札术朴机杀杂权条来杨杩杰极构枞枢枣枥枧枨枪枫枭柜柠柽栀栅标栈栉栊栋栌栎栏树栖样栾桊桠桡桢档桤桥桦桧桨桩梦梼梾检棂椁椟椠椤椭楼榄榇榈榉槚槛槟槠横樯樱橥橱橹橼檐檩欢欤欧歼殁殇残殒殓殚殡殴毁毂毕毙毡毵氇气氢氩氲汇汉污汤汹沓沟没沣沤沥沦沧沨沩沪沵泞泪泶泷泸泺泻泼泽泾洁洒洼浃浅浆浇浈浉浊测浍济浏浐浑浒浓浔浕涂涌涛涝涞涟涠涡涢涣涤润涧涨涩淀渊渌渍渎渐渑渔渖渗温游湾湿溃溅溆溇滗滚滞滟滠满滢滤滥滦滨滩滪漤潆潇潋潍潜潴澜濑濒灏灭灯灵灾灿炀炉炖炜炝点炼炽烁烂烃烛烟烦烧烨烩烫烬热焕焖焘煅煳熘爱爷牍牦牵牺犊犟状犷犸犹狈狍狝狞独狭狮狯狰狱狲猃猎猕猡猪猫猬献獭玑玙玚玛玮环现玱玺珉珏珐珑珰珲琎琏琐琼瑶瑷璇璎瓒瓮瓯电画畅畲畴疖疗疟疠疡疬疮疯疱疴痈痉痒痖痨痪痫痴瘅瘆瘗瘘瘪瘫瘾瘿癞癣癫癯皑皱皲盏盐监盖盗盘眍眦眬着睁睐睑瞒瞩矫矶矾矿砀码砖砗砚砜砺砻砾础硁硅硕硖硗硙硚确硷碍碛碜碱碹磙礼祎祢祯祷祸禀禄禅离秃秆种积称秽秾稆税稣稳穑穷窃窍窑窜窝窥窦窭竖竞笃笋笔笕笺笼笾筑筚筛筜筝筹签简箓箦箧箨箩箪箫篑篓篮篱簖籁籴类籼粜粝粤粪粮糁糇紧絷纟纠纡红纣纤纥约级纨纩纪纫纬纭纮纯纰纱纲纳纴纵纶纷纸纹纺纻纼纽纾线绀绁绂练组绅细织终绉绊绋绌绍绎经绐绑绒结绔绕绖绗绘给绚绛络绝绞统绠绡绢绣绤绥绦继绨绩绪绫绬续绮绯绰绱绲绳维绵绶绷绸绹绺绻综绽绾绿缀缁缂缃缄缅缆缇缈缉缊缋缌缍缎缏缐缑缒缓缔缕编缗缘缙缚缛缜缝缞缟缠缡缢缣缤缥缦缧缨缩缪缫缬缭缮缯缰缱缲缳缴缵罂网罗罚罢罴羁羟羡翘翙翚耢耧耸耻聂聋职聍联聵聽聰肅腸膚膁腎腫脹脅膽勝朧腖臚脛膠脈膾髒臍腦膿臠腳脫腡臉臘醃膕齶膩靦膃騰臏臢輿艤艦艙艫艱豔艸藝節羋薌蕪蘆蓯葦藶莧萇蒼苧蘇檾蘋莖蘢蔦塋煢繭荊薦薘莢蕘蓽蕎薈薺蕩榮葷滎犖熒蕁藎蓀蔭蕒葒葤藥蒞蓧萊蓮蒔萵薟獲蕕瑩鶯蓴蘀蘿螢營縈蕭薩蔥蕆蕢蔣蔞藍薊蘺蕷鎣驀薔蘞藺藹蘄蘊藪槁蘚虜慮虛蟲虯虮雖蝦蠆蝕蟻螞蠶蠔蜆蠱蠣蟶蠻蟄蛺蟯螄蠐蛻蝸蠟蠅蟈蟬蠍螻蠑螿蟎蠨釁銜補襯袞襖嫋褘襪襲襏裝襠褌褳襝褲襇褸襤繈襴見觀覎規覓視覘覽覺覬覡覿覥覦覯覲覷觴觸觶讋譽謄訁計訂訃認譏訐訌討讓訕訖訓議訊記訒講諱謳詎訝訥許訛論訩訟諷設訪訣證詁訶評詛識詗詐訴診詆謅詞詘詔詖譯詒誆誄試詿詩詰詼誠誅詵話誕詬詮詭詢詣諍該詳詫諢詡譸誡誣語誚誤誥誘誨誑說誦誒請諸諏諾讀諑誹課諉諛誰諗調諂諒諄誶談誼謀諶諜謊諫諧謔謁謂諤諭諼讒諮諳諺諦謎諞諝謨讜謖謝謠謗諡謙謐謹謾謫譾謬譚譖譙讕譜譎讞譴譫讖穀豶貝貞負貟貢財責賢敗賬貨質販貪貧貶購貯貫貳賤賁貰貼貴貺貸貿費賀貽賊贄賈賄貲賃賂贓資賅贐賕賑賚賒賦賭齎贖賞賜贔賙賡賠賧賴賵贅賻賺賽賾贗讚贇贈贍贏贛赬趙趕趨趲躉躍蹌蹠躒踐躂蹺蹕躚躋踴躊蹤躓躑躡蹣躕躥躪躦軀車軋軌軑軔轉軛輪軟轟軲軻轤軸軹軼軤軫轢軺輕軾載輊轎輈輇輅較輒輔輛輦輩輝輥輞輬輟輜輳輻輯轀輸轡轅轄輾轆轍轔辯辮邊遼達遷過邁運還這進遠違連遲邇逕跡適選遜遞邐邏遺遙鄧鄺鄔郵鄒鄴鄰鬱郤郟鄶鄭鄆酈鄖鄲醞醱醬釅釃釀釋裏钜鑒鑾鏨釓釔針釘釗釙釕釷釺釧釤鈒釩釣鍆釹鍚釵鈃鈣鈈鈦鈍鈔鍾鈉鋇鋼鈑鈐鑰欽鈞鎢鉤鈧鈁鈥鈄鈕鈀鈺錢鉦鉗鈷缽鈳鉕鈽鈸鉞鑽鉬鉭鉀鈿鈾鐵鉑鈴鑠鉛鉚鈰鉉鉈鉍鈹鐸鉶銬銠鉺銪鋏鋣鐃銍鐺銅鋁銱銦鎧鍘銖銑鋌銩銛鏵銓鉿銚鉻銘錚銫鉸銥鏟銃鐋銨銀銣鑄鐒鋪鋙錸鋱鏈鏗銷鎖鋰鋥鋤鍋鋯鋨鏽銼鋝鋒鋅鋶鐦鐧銳銻鋃鋟鋦錒錆鍺錯錨錡錁錕錩錫錮鑼錘錐錦鍁錈錇錟錠鍵鋸錳錙鍥鍈鍇鏘鍶鍔鍤鍬鍾鍛鎪鍠鍰鎄鍍鎂鏤鎡鏌鎮鎛鎘鑷鐫鎳鎿鎦鎬鎊鎰鎔鏢鏜鏍鏰鏞鏡鏑鏃鏇鏐鐔钁鐐鏷鑥鐓鑭鐠鑹鏹鐙鑊鐳鐶鐲鐮鐿鑔鑣鑞鑲長門閂閃閆閈閉問闖閏闈閑閎間閔閌悶閘鬧閨聞闼閩閭闓閥閣閡閫鬮閱閬闍閾閹閶鬩閿閽閻閼闡闌闃闠闊闋闔闐闒闕闞闤隊陽陰陣階際陸隴陳陘陝隉隕險隨隱隸雋難雛讎靂霧霽黴靄靚靜靨韃鞽韉韝韋韌韍韓韙韞韜韻页顶顷顸项顺须顼顽顾顿颀颁颂颃预颅领颇颈颉颊颋颌颍颎颏颐频颒颓颔颕颖颗题颙颚颛颜额颞颟颠颡颢颣颤颥颦颧风飏飐飑飒飓飔飕飖飗飘飙飚飞飨餍饤饥饦饧饨饩饪饫饬饭饮饯饰饱饲饳饴饵饶饷饸饹饺饻饼饽饾饿馀馁馂馃馄馅馆馇馈馉馊馋馌馍馎馏馐馑馒馓馔馕马驭驮驯驰驱驲驳驴驵驶驷驸驹驺驻驼驽驾驿骀骁骂骃骄骅骆骇骈骉骊骋验骍骎骏骐骑骒骓骔骕骖骗骘骙骚骛骜骝骞骟骠骡骢骣骤骥骦骧髅髋髌鬓魇魉鱼鱽鱾鱿鲀鲁鲂鲄鲅鲆鲇鲈鲉鲊鲋鲌鲍鲎鲏鲐鲑鲒鲓鲔鲕鲖鲗鲘鲙鲚鲛鲜鲝鲞鲟鲠鲡鲢鲣鲤鲥鲦鲧鲨鲩鲪鲫鲬鲭鲮鲯鲰鲱鲲鲳鲴鲵鲶鲷鲸鲹鲺鲻鲼鲽鲾鲿鳀鳁鳂鳃鳄鳅鳆鳇鳈鳉鳊鳋鳌鳍鳎鳏鳐鳑鳒鳓鳔鳕鳖鳗鳘鳙鳛鳜鳝鳞鳟鳠鳡鳢鳣鸟鸠鸡鸢鸣鸤鸥鸦鸧鸨鸩鸪鸫鸬鸭鸮鸯鸰鸱鸲鸳鸴鸵鸶鸷鸸鸹鸺鸻鸼鸽鸾鸿鹀鹁鹂鹃鹄鹅鹆鹇鹈鹉鹊鹋鹌鹍鹎鹏鹐鹑鹒鹓鹔鹕鹖鹗鹘鹚鹛鹜鹝鹞鹟鹠鹡鹢鹣鹤鹥鹦鹧鹨鹩鹪鹫鹬鹭鹯鹰鹱鹲鹳鹴鹾麦麸黄黉黡黩黪黾鼋鼌鼍鼗鼹齄齐齑齿龀龁龂龃龄龅龆龇龈龉龊龋龌龙龚龛龟志制咨只里系范松没尝尝闹面准钟别闲干尽脏拼]/gu;
             const tradRegex = /[萬與醜專業叢東絲丟兩嚴喪個爿豐臨為麗舉麼義烏樂喬習鄉書買亂爭於虧雲亙亞產畝親褻嚲億僅從侖倉儀們價眾優夥會傴傘偉傳傷倀倫傖偽佇體餘傭僉俠侶僥偵側僑儈儕儂俁儔儼倆儷儉債傾傯僂僨償儻儐儲儺兒兌兗黨蘭關興茲養獸囅內岡冊寫軍農塚馮衝決況凍淨淒涼淩減湊凜幾鳳鳧憑凱擊氹鑿芻劃劉則剛創刪別剗剄劊劌剴劑剮劍剝劇勸辦務勱動勵勁勞勣勳猛勩勻匭匱區醫華協單賣盧鹵臥衛卻巹廠廳曆厲壓厭厙廁廂厴廈廚廄廝縣參靉靆雙發變敘疊葉號歎嘰籲後嚇呂嗎唚噸聽啟吳嘸囈嘔嚦唄員咼嗆嗚詠哢嚨嚀噝吒噅鹹呱響啞噠嘵嗶噦嘩噲嚌噥喲嘜嗊嘮啢嗩唕喚呼嘖嗇囀齧囉嘽嘯噴嘍嚳囁嗬噯噓嚶囑嚕劈囂謔團園囪圍圇國圖圓聖壙場阪壞塊堅壇壢壩塢墳墜壟壟壚壘墾坰堊墊埡墶壋塏堖塒塤堝墊垵塹墮壪牆壯聲殼壺壼處備複夠頭誇夾奪奩奐奮獎奧妝婦媽嫵嫗媯姍薑婁婭嬈嬌孌娛媧嫻嫿嬰嬋嬸媼嬡嬪嬙嬤孫學孿寧寶實寵審憲宮寬賓寢對尋導壽將爾塵堯尷屍盡層屭屜屆屬屢屨嶼歲豈嶇崗峴嶴嵐島嶺嶽崠巋嶨嶧峽嶢嶠崢巒嶗崍嶮嶄嶸嶔崳嶁脊巔鞏巰幣帥師幃帳簾幟帶幀幫幬幘幗冪襆幹並廣莊慶廬廡庫應廟龐廢廎廩開異棄張彌弳彎彈強歸當錄彠彥徹徑徠禦憶懺憂愾懷態慫憮慪悵愴憐總懟懌戀懇惡慟懨愷惻惱惲悅愨懸慳憫驚懼慘懲憊愜慚憚慣湣慍憤憒願懾憖怵懣懶懍戇戔戲戧戰戬戶紮撲扡執擴捫掃揚擾撫拋摶摳掄搶護報擔擬攏揀擁攔擰撥擇掛摯攣掗撾撻挾撓擋撟掙擠揮撏撈損撿換搗據撚擄摑擲撣摻摜摣攬撳攙擱摟攪攜攝攄擺搖擯攤攖撐攆擷擼攛擻攢敵斂數齋斕鬥斬斷無舊時曠暘曇晝曨顯晉曬曉曄暈暉暫曖劄術樸機殺雜權條來楊榪傑極構樅樞棗櫪梘棖槍楓梟櫃檸檉梔柵標棧櫛櫳棟櫨櫟欄樹棲樣欒棬椏橈楨檔榿橋樺檜槳樁夢檮棶檢欞槨櫝槧欏橢樓欖櫬櫚櫸檟檻檳櫧橫檣櫻櫫櫥櫓櫞簷檁歡歟歐殲歿殤殘殞殮殫殯毆毀轂畢斃氈毿氌氣氫氬氲彙漢汙湯洶遝溝沒灃漚瀝淪滄渢溈滬濔濘淚澩瀧瀘濼瀉潑澤涇潔灑窪浹淺漿澆湞溮濁測澮濟瀏滻渾滸濃潯濜塗湧濤澇淶漣潿渦溳渙滌潤澗漲澀澱淵淥漬瀆漸澠漁瀋滲溫遊灣濕潰濺漵漊潷滾滯灩灄滿瀅濾濫灤濱灘澦濫瀠瀟瀲濰潛瀦瀾瀨瀕灝滅燈靈災燦煬爐燉煒熗點煉熾爍爛烴燭煙煩燒燁燴燙燼熱煥燜燾煆糊溜愛爺牘犛牽犧犢強狀獷獁猶狽麅獮獰獨狹獅獪猙獄猻獫獵獼玀豬貓蝟獻獺璣璵瑒瑪瑋環現瑲璽瑉玨琺瓏璫琿璡璉瑣瓊瑤璦璿瓔瓚甕甌電畫暢佘疇癤療瘧癘瘍鬁瘡瘋皰屙癰痙癢瘂癆瘓癇癡癉瘮瘞瘺癟癱癮癭癩癬癲臒皚皺皸盞鹽監蓋盜盤瞘眥矓著睜睞瞼瞞矚矯磯礬礦碭碼磚硨硯碸礪礱礫礎硜矽碩硤磽磑礄確鹼礙磧磣堿镟滾禮禕禰禎禱禍稟祿禪離禿稈種積稱穢穠穭稅穌穩穡窮竊竅窯竄窩窺竇窶豎競篤筍筆筧箋籠籩築篳篩簹箏籌簽簡籙簀篋籜籮簞簫簣簍籃籬籪籟糴類秈糶糲粵糞糧糝餱緊縶糸糾紆紅紂纖紇約級紈纊紀紉緯紜紘純紕紗綱納紝縱綸紛紙紋紡紵紖紐紓線紺絏紱練組紳細織終縐絆紼絀紹繹經紿綁絨結絝繞絰絎繪給絢絳絡絕絞統綆綃絹繡綌綏絛繼綈績緒綾緓續綺緋綽緔緄繩維綿綬繃綢綯綹綣綜綻綰綠綴緇緙緗緘緬纜緹緲緝縕繢緦綞緞緶線緱縋緩締縷編緡緣縉縛縟縝縫縗縞纏縭縊縑繽縹縵縲纓縮繆繅纈繚繕繒韁繾繰繯繳纘罌網羅罰罷羆羈羥羨翹翽翬耮耬聳恥聶聾職聹聯聵聽聰肅腸膚膁腎腫脹脅膽勝朧腖臚脛膠脈膾髒臍腦膿臠腳脫腡臉臘醃膕齶膩靦膃騰臏臢輿艤艦艙艫艱豔艸藝節羋薌蕪蘆蓯葦藶莧萇蒼苧蘇檾蘋莖蘢蔦塋煢繭荊薦薘莢蕘蓽蕎薈薺蕩榮葷滎犖熒蕁藎蓀蔭蕒葒葤藥蒞蓧萊蓮蒔萵薟獲蕕瑩鶯蓴蘀蘿螢營縈蕭薩蔥蕆蕢蔣蔞藍薊蘺蕷鎣驀薔蘞藺藹蘄蘊藪槁蘚虜慮虛蟲虯虮雖蝦蠆蝕蟻螞蠶蠔蜆蠱蠣蟶蠻蟄蛺蟯螄蠐蛻蝸蠟蠅蟈蟬蠍螻蠑螿蟎蠨釁銜補襯袞襖嫋褘襪襲襏裝襠褌褳襝褲襇褸襤繈襴見觀覎規覓視覘覽覺覬覡覿覥覦覯覲覷觴觸觶讋譽謄訁計訂訃認譏訐訌討讓訕訖訓議訊記訒講諱謳詎訝訥許訛論訩訟諷設訪訣證詁訶評詛識詗詐訴診詆謅詞詘詔詖譯詒誆誄試詿詩詰詼誠誅詵話誕詬詮詭詢詣諍該詳詫諢詡譸誡誣語誚誤誥誘誨誑說誦誒請諸諏諾讀諑誹課諉諛誰諗調諂諒諄誶談誼謀諶諜謊諫諧謔謁謂諤諭諼讒諮諳諺諦謎諞諝謨讜謖謝謠謗諡謙謐謹謾謫譾謬譚譖譙讕譜譎讞譴譫讖穀豶貝貞負貟貢財責賢敗賬貨質販貪貧貶購貯貫貳賤賁貰貼貴貺貸貿費賀貽賊贄賈賄貲賃賂贓資賅贐賕賑賚賒賦賭齎贖賞賜贔賙賡賠賧賴賵贅賻賺賽賾贗讚贇贈贍贏贛赬趙趕趨趲躉躍蹌蹠躒踐躂蹺蹕躚躋踴躊蹤躓躑躡蹣躕躥躪躦軀車軋軌軑軔轉軛輪軟轟軲軻轤軸軹軼軤軫轢軺輕軾載輊轎輈輇輅較輒輔輛輦輩輝輥輞輬輟輜輳輻輯轀輸轡轅轄輾轆轍轔辯辮邊遼達遷過邁運還這進遠違連遲邇逕跡適選遜遞邐邏遺遙鄧鄺鄔郵鄒鄴鄰鬱郤郟鄶鄭鄆酈鄖鄲醞醱醬釅釃釀釋裏钜鑒鑾鏨釓釔針釘釗釙釕釷釺釧釤鈒釩釣鍆釹鍚釵鈃鈣鈈鈦鈍鈔鍾鈉鋇鋼鈑鈐鑰欽鈞鎢鉤鈧鈁鈥鈄鈕鈀鈺錢鉦鉗鈷缽鈳鉕鈽鈸鉞鑽鉬鉭鉀鈿鈾鐵鉑鈴鑠鉛鉚鈰鉉鉈鉍鈹鐸鉶銬銠鉺銪鋏鋣鐃銍鐺銅鋁銱銦鎧鍘銖銑鋌銩銛鏵銓鉿銚鉻銘錚銫鉸銥鏟銃鐋銨銀銣鑄鐒鋪鋙錸鋱鏈鏗銷鎖鋰鋥鋤鍋鋯鋨鏽銼鋝鋒鋅鋶鐦鐧銳銻鋃鋟鋦錒錆鍺錯錨錡錁錕錩錫錮鑼錘錐錦鍁錈錇錟錠鍵鋸錳錙鍥鍈鍇鏘鍶鍔鍤鍬鍾鍛鎪鍠鍰鎄鍍鎂鏤鎡鏌鎮鎛鎘鑷鐫鎳鎿鎦鎬鎊鎰鎔鏢鏜鏍鏰鏞鏡鏑鏃鏇鏐鐔钁鐐鏷鑥鐓鑭鐠鑹鏹鐙鑊鐳鐶鐲鐮鐿鑔鑣鑞鑲長門閂閃閆閈閉問闖閏闈閑閎間閔閌悶閘鬧閨聞闼閩閭闓閥閣閡閫鬮閱閬闍閾閹閶鬩閿閽閻閼闡闌闃闠闊闋闔闐闒闕闞闤隊陽陰陣階際陸隴陳陘陝隉隕險隨隱隸雋難雛讎靂霧霽黴靄靚靜靨韃鞽韉韝韋韌韍韓韙韞韜韻页顶顷顸项顺须顼顽顾顿颀颁颂颃预颅领颇颈颉颊颋颌颍颎颏颐频颒颓颔颕颖颗题颙颚颛颜额颞颟颠颡颢颣颤颥颦颧风飏飐飑飒飓飔飕飖飗飘飙飚飞飨餍饤饥饦饧饨饩饪饫饬饭饮饯饰饱饲饳饴饵饶饷饸饹饺饻饼饽饾饿馀馁馂馃馄馅馆馇馈馉馊馋馌馍馎馏馐馑馒馓馔馕马驭驮驯驰驱驲驳驴驵驶驷驸驹驺驻驼驽驾驿骀骁骂骃骄骅骆骇骈骉骊骋验骍骎骏骐骑骒骓骔骕骖骗骘骙骚骛骜骝骞骟骠骡骢骣骤骥骦骧髅髋髌鬓魇魉鱼鱽鱾鱿鲀鲁鲂鲄鲅鲆鲇鲈鲉鲊鲋鲌鲍鲎鲏鲐鲑鲒鲓鲔鲕鲖鲗鲘鲙鲚鲛鲜鲝鲞鲟鲠鲡鲢鲣鲤鲥鲦鲧鲨鲩鲪鲫鲬鲭鲮鲯鲰鲱鲲鲳鲴鲵鲶鲷鲸鲹鲺鲻鲼鲽鲾鲿鳀鳁鳂鳃鳄鳅鳆鳇鳈鳉鳊鳋鳌鳍鳎鳏鳐鳑鳒鳓鳔鳕鳖鳗鳘鳙鳛鳜鳝鳞鳟鳠鳡鳢鳣鸟鸠鸡鸢鸣鸤鸥鸦鸧鸨鸩鸪鸫鸬鸭鸮鸯鸰鸱鸲鸳鸴鸵鸶鸷鸸鸹鸺鸻鸼鸽鸾鸿鹀鹁鹂鹃鹄鹅鹆鹇鹈鹉鹊鹋鹌鹍鹎鹏鹐鹑鹒鹓鹔鹕鹖鹗鹘鹚鹛鹜鹝鹞鹟鹠鹡鹢鹣鹤鹥鹦鹧鹨鹩鹪鹫鹬鹭鹯鹰鹱鹲鹳鹴鹾麦麸黄黉黡黩黪黾鼋鼌鼍鼗鼹齄齐齑齿龀龁龂龃龄龅龆龇龈龉龊龋龌龙龚龛龟志制咨只里系范松没尝尝闹面准钟别闲干尽脏拼]/gu;
             const hanziRegex = /\p{Script=Han}/gu;
@@ -481,15 +485,14 @@
             const czechRegex = /[áčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]/gu;
             const czechUniqueRegex = /[ěĚřŘůŮ]/gu;
             const arabicRegex = /[\u0600-\u06FF]/gu;
+            // Persian shares the Arabic block, so it is only separable by the
+            // letters Arabic does not use: peh, tcheh, jeh, gaf, keheh, farsi yeh.
+            const persianUniqueRegex = /[\u067E\u0686\u0698\u06AF\u06A9\u06CC]/gu;
             const thaiRegex = /[\u0E00-\u0E7F]/gu;
             const devanagariRegex = /[\u0900-\u097F]/gu;
+            const bengaliRegex = /[\u0980-\u09FF]/gu;
             const latinExtendedRegex = /\p{Script=Latin}/gu;
             const latinWordRegex = /\p{Script=Latin}+(?:['’]\p{Script=Latin}+)?/gu;
-
-            const cjkMatchRegex = this._cjkMatchRegex || (
-                this._cjkMatchRegex = new RegExp(`${kanaRegex.source}|${hanziRegex.source}|${hangulRegex.source}`, "gu")
-            );
-            const cjkMatch = rawLyrics.match(cjkMatchRegex);
 
             const cyrillicMatch = rawLyrics.match(cyrillicRegex);
             const vietnameseMatch = rawLyrics.match(vietnameseRegex);
@@ -508,8 +511,10 @@
             const czechMatch = rawLyrics.match(czechRegex);
             const czechUniqueMatch = rawLyrics.match(czechUniqueRegex);
             const arabicMatch = rawLyrics.match(arabicRegex);
+            const persianUniqueMatch = rawLyrics.match(persianUniqueRegex);
             const thaiMatch = rawLyrics.match(thaiRegex);
             const hindiMatch = rawLyrics.match(devanagariRegex);
+            const bengaliMatch = rawLyrics.match(bengaliRegex);
             const latinMatch = rawLyrics.match(latinExtendedRegex);
             const normalizedLatinLyrics = rawLyrics.toLowerCase().normalize("NFC");
             const latinWords = normalizedLatinLyrics.match(latinWordRegex) || [];
@@ -518,7 +523,8 @@
                 if (latinWords.length < 4) {
                     if (/\b(aku cinta kamu|aku sayang kamu|cinta kamu)\b/u.test(normalizedLatinLyrics)) return "id";
                     if (/\b(aku sayang awak|saya sayang awak|cinta awak)\b/u.test(normalizedLatinLyrics)) return "ms";
-                    return null;
+                    // Fragments still get scored below on a lower bar. Bailing
+                    // out here sent every short line to the English catch-all.
                 }
 
                 const languageHints = {
@@ -573,6 +579,10 @@
                     ms: {
                         strong: ["aku", "saya", "awak", "kau", "tidak", "tak", "mahu", "boleh", "kerana", "denganmu", "bersamamu", "dirimu", "cinta", "hati", "hatiku", "rindu", "malam", "sendiri", "selalu", "pernah"],
                         weak: ["yang", "dan", "di", "ke", "dari", "untuk", "dengan", "ini", "itu", "ada", "akan", "bukan", "hanya", "jangan", "semua", "tanpa", "percaya"]
+                    },
+                    vi: {
+                        strong: ["anh", "em", "tôi", "không", "của", "yêu", "đêm", "một", "những", "người", "biết", "quên", "được", "thương", "nhớ", "lòng", "đời", "mãi"],
+                        weak: ["và", "cho", "với", "này", "khi", "rồi", "vẫn", "chỉ", "đã", "sẽ", "lại", "thêm"]
                     }
                 };
 
@@ -599,7 +609,19 @@
                 scores.tr += charBonus(/[ğıış]/gu, 5) + charBonus(/[ç]/gu, 2);
                 scores.cs += charBonus(/[ěřů]/gu, 5) + charBonus(/[čďňšťž]/gu, 2);
                 scores.sv += charBonus(/[å]/gu, 5) + charBonus(/[äö]/gu, 1);
-                scores.fr += charBonus(/[æœçëïÿêèùû]/gu, 3);
+                // ê, è, ù and û are shared with Vietnamese, which uses them far
+                // more densely. Only credit French for them when no Vietnamese-
+                // only letter is present, otherwise Vietnamese lyrics collect a
+                // large French bonus with nothing to offset it.
+                const vietnameseSignal = vietnameseUniqueMatch ? vietnameseUniqueMatch.length : 0;
+                scores.vi += vietnameseSignal * 3;
+                // ç, œ, æ, ë, ï and ÿ are distinctively French. ê, è, ù and û
+                // are shared with Italian and Portuguese, which use them just
+                // as densely -- Italian "è" is the copula and appears in almost
+                // every line -- so crediting them to French at full weight
+                // handed French any Romance lyric with enough accents, even
+                // when the correct language led the word scoring outright.
+                scores.fr += charBonus(/[æœçëïÿ]/gu, 3) + (vietnameseSignal ? 0 : charBonus(/[êèùû]/gu, 1));
                 scores.es += charBonus(/[ñ¿¡]/gu, 5) + charBonus(/[áéíóú]/gu, 1);
                 scores.pt += charBonus(/[ãõ]/gu, 5) + charBonus(/[ç]/gu, 1);
                 scores.pl += charBonus(/[ąćęłńśźż]/gu, 5);
@@ -610,6 +632,15 @@
                 if (/\b(i am|you are|don't|can't|with you|for you|my heart)\b/u.test(normalizedLatinLyrics)) {
                     scores.en += 4;
                 }
+
+                // English is the only candidate written in plain ASCII, so every
+                // accented letter is evidence against it. Function words overlap
+                // heavily between languages ("no" scores for English and Spanish
+                // alike), which let a short English hook outscore the language
+                // the rest of the song is actually written in. Capped so that a
+                // stray loanword in a genuinely English lyric cannot sink it.
+                const accentedLetterCount = (normalizedLatinLyrics.match(/\P{ASCII}/gu) || []).length;
+                scores.en -= Math.min(accentedLetterCount, 8);
                 if (/\b(je suis|tu es|avec toi|mon coeur|mon cœur|pour toi)\b/u.test(normalizedLatinLyrics)) {
                     scores.fr += 4;
                 }
@@ -623,158 +654,187 @@
                     scores.ms += 4;
                 }
 
+                // Languages whose orthography effectively always carries
+                // diacritics should not win on text that has none. Lyric
+                // providers serve a lot of romanized transcriptions (romaji,
+                // romanized Hindi), and without this they get claimed by
+                // whichever European language their vowel pattern happens to
+                // fit -- so the UI then offers an unrelated conversion. Halved
+                // rather than vetoed so that strong word evidence still wins.
+                // English, Indonesian, Malay and Dutch are excluded: those are
+                // legitimately written without diacritics.
+                const diacriticBearing = {
+                    es: /[áéíóúüñ¿¡]/u,
+                    cs: /[áčďéěíňóřšťúůýž]/u,
+                    fr: /[àâæçéèêëïîôùûüÿœ]/u,
+                    it: /[àèéìòù]/u,
+                    pl: /[ąćęłńóśźż]/u,
+                    pt: /[ãõáàâéêíóôúüç]/u,
+                    tr: /[çğıöşü]/u,
+                    de: /[äöüß]/u,
+                    sv: /[åäö]/u,
+                    vi: /[đươăạảấầẩẫậắằẳẵặếềểễệốồổỗộớờởỡợụủứừửữựỳỵỷỹ]/u
+                };
+                // Only applied to running text: the romanized transcriptions
+                // this guards against are full songs, whereas a short phrase
+                // ("te quiero") can be perfectly ordinary Spanish and still
+                // contain no accent at all.
+                if (latinWords.length >= 8) {
+                    Object.entries(diacriticBearing).forEach(([lang, pattern]) => {
+                        if (scores[lang] > 0 && !pattern.test(normalizedLatinLyrics)) {
+                            scores[lang] = Math.floor(scores[lang] / 2);
+                        }
+                    });
+                }
+
                 const sorted = Object.entries(scores).sort((left, right) => right[1] - left[1]);
                 const [bestLang, bestScore] = sorted[0];
                 const nextScore = sorted[1]?.[1] || 0;
-                const minScore = latinWords.length < 8 ? 4 : 5;
+                // A fragment cannot clear the bar set for running text, so it is
+                // judged on whether it contains a distinctive word at all.
+                const minScore = latinWords.length < 4 ? 2 : (latinWords.length < 8 ? 4 : 5);
 
                 if (bestScore >= minScore && bestScore - nextScore >= 2) {
+                    return bestLang;
+                }
+
+                // Close relatives such as Indonesian and Malay share most of
+                // their vocabulary and routinely tie. Returning null here used
+                // to fall through to the English catch-all, answering with a
+                // language that never scored at all -- the leader is a better
+                // answer than English whenever anything scored meaningfully.
+                if (bestScore >= minScore) {
                     return bestLang;
                 }
                 return null;
             };
 
-            // Arabic
-            if (arabicMatch && arabicMatch.length > 5) {
-                this._cacheLanguageResult(cacheKey, "ar");
-                return "ar";
-            }
-            // Thai
-            if (thaiMatch && thaiMatch.length > 5) {
-                this._cacheLanguageResult(cacheKey, "th");
-                return "th";
-            }
-            // Hindi
-            if (hindiMatch && hindiMatch.length > 5) {
-                this._cacheLanguageResult(cacheKey, "hi");
-                return "hi";
-            }
-            // Russian
-            if (cyrillicMatch && cyrillicMatch.length > 10) {
-                this._cacheLanguageResult(cacheKey, "ru");
-                return "ru";
+            // ---- Weigh the evidence -----------------------------------------
+            // Each candidate is scored on how much of the lyric text it accounts
+            // for, and the strongest wins. This replaces an ordered chain of
+            // early returns in which whichever check ran first won outright: a
+            // single foreign glyph in a hook could relabel an entire song, and
+            // the raw-count thresholds did not scale with lyric length.
+            const totalScriptChars = (rawLyrics.match(/\S/gu) || []).length || 1;
+
+            const hangulCount = (rawLyrics.match(hangulRegex) || []).length;
+            const kanaCount = (rawLyrics.match(kanaRegex) || []).length;
+            const hanChars = rawLyrics.match(hanziRegex) || [];
+            const cjkCharCount = hangulCount + kanaCount + hanChars.length;
+
+            const shareOfText = (count) => count / totalScriptChars;
+
+            // A song's actual language covers a meaningful share of the text.
+            // A borrowed hook, a loanword or a stray glyph does not.
+            const DOMINANT_SCRIPT_SHARE = 0.12;
+
+            const resolveCjkLanguage = () => {
+                // Korean is the only CJK language that uses Hangul at all.
+                if (hangulCount / cjkCharCount >= 0.2) {
+                    return "ko";
+                }
+
+                const jaThreshold = Number(Spicetify.LocalStorage.get("ivLyrics:visual:ja-detect-threshold")) || 40;
+                const kanaPercentage = kanaCount / cjkCharCount;
+                const hanziPercentage = hanChars.length / cjkCharCount;
+                if (((kanaPercentage - hanziPercentage + 1) / 2) * 100 >= jaThreshold) {
+                    return "ja";
+                }
+
+                // `.test()` on a /g/ regex advances lastIndex between calls, so
+                // the shared simplified/traditional matchers need non-global
+                // copies to classify one character at a time.
+                const simpTestRegex = new RegExp(simpRegex.source, "u");
+                const tradTestRegex = new RegExp(tradRegex.source, "u");
+
+                let simpCount = 0;
+                let tradCount = 0;
+                hanChars.forEach((glyph) => {
+                    if (simpTestRegex.test(glyph)) simpCount++;
+                    if (tradTestRegex.test(glyph)) tradCount++;
+                });
+
+                // Simplified and traditional Chinese share most characters, so
+                // the ratio is taken over the glyphs that actually differ. Taken
+                // over every Han character the shared majority dominated and
+                // pulled effectively all Chinese text toward simplified.
+                const distinguishing = simpCount + tradCount;
+                const hansThreshold = Number(Spicetify.LocalStorage.get("ivLyrics:visual:hans-detect-threshold")) || 40;
+                if (distinguishing === 0) {
+                    return "zh-hans";
+                }
+                const simpPercentage = simpCount / distinguishing;
+                const tradPercentage = tradCount / distinguishing;
+                return ((simpPercentage - tradPercentage + 1) / 2) * 100 >= hansThreshold ? "zh-hans" : "zh-hant";
+            };
+
+            const scriptCandidates = [
+                ["cjk", shareOfText(cjkCharCount)],
+                ["ru", shareOfText(cyrillicMatch ? cyrillicMatch.length : 0)],
+                ["ar", shareOfText(arabicMatch ? arabicMatch.length : 0)],
+                ["th", shareOfText(thaiMatch ? thaiMatch.length : 0)],
+                ["hi", shareOfText(hindiMatch ? hindiMatch.length : 0)],
+                ["bn", shareOfText(bengaliMatch ? bengaliMatch.length : 0)]
+            ].sort((left, right) => right[1] - left[1]);
+
+            const [dominantScript, dominantShare] = scriptCandidates[0];
+
+            if (dominantShare >= DOMINANT_SCRIPT_SHARE) {
+                let resolved = dominantScript;
+
+                if (dominantScript === "cjk") {
+                    resolved = resolveCjkLanguage();
+                } else if (dominantScript === "ar") {
+                    // Persian is written in the Arabic block and is separable
+                    // only by the letters Arabic itself does not use. Measured
+                    // as a share of the Arabic-block text rather than as a raw
+                    // count: Arabic lyrics occasionally carry a stray Persian
+                    // letter form, while genuine Persian is dense with them.
+                    // Across 121 sampled songs the populations separate cleanly
+                    // -- Arabic peaks at 0.055, Persian starts at 0.087.
+                    const persianCount = persianUniqueMatch ? persianUniqueMatch.length : 0;
+                    const arabicCount = arabicMatch ? arabicMatch.length : 0;
+                    resolved = arabicCount > 0 && (persianCount / arabicCount) >= 0.07 ? "fa" : "ar";
+                }
+
+                this._cacheLanguageResult(cacheKey, resolved);
+                return resolved;
             }
 
-            // Vietnamese vs French
-            const vietnameseUniqueCount = vietnameseUniqueMatch ? vietnameseUniqueMatch.length : 0;
-            const frenchUniqueCount = frenchUniqueMatch ? frenchUniqueMatch.length : 0;
-            const vietnameseCount = vietnameseMatch ? vietnameseMatch.length : 0;
-            const frenchCount = frenchMatch ? frenchMatch.length : 0;
-            const swedishCount = swedishMatch ? swedishMatch.length : 0;
-            const swedishUniqueCount = swedishUniqueMatch ? swedishUniqueMatch.length : 0;
-            const germanUniqueCount = germanUniqueMatch ? germanUniqueMatch.length : 0;
-            const turkishUniqueCount = turkishUniqueMatch ? turkishUniqueMatch.length : 0;
-            const czechUniqueCount = czechUniqueMatch ? czechUniqueMatch.length : 0;
-            const latinScoreLanguage = !cjkMatch ? detectLatinLanguageByScore() : null;
-
+            // ---- Latin scripts ----------------------------------------------
+            const latinScoreLanguage = detectLatinLanguageByScore();
             if (latinScoreLanguage) {
                 this._cacheLanguageResult(cacheKey, latinScoreLanguage);
                 return latinScoreLanguage;
             }
 
-            if (vietnameseUniqueCount >= 2) {
-                this._cacheLanguageResult(cacheKey, "vi");
-                return "vi";
-            }
-            if (frenchUniqueCount >= 1 && frenchCount > 3) {
-                this._cacheLanguageResult(cacheKey, "fr");
-                return "fr";
-            }
-            if (frenchCount > 5 && vietnameseUniqueCount === 0) {
-                this._cacheLanguageResult(cacheKey, "fr");
-                return "fr";
-            }
-            if (vietnameseCount > 5 && vietnameseUniqueCount >= 1) {
-                this._cacheLanguageResult(cacheKey, "vi");
-                return "vi";
+            // Stopword scoring needs running text. When it cannot decide, fall
+            // back to diacritics, weighting letters only one language uses far
+            // above letters several languages share.
+            const countOf = (match) => (match ? match.length : 0);
+
+            const diacriticCandidates = [
+                ["vi", countOf(vietnameseUniqueMatch) * 3 + countOf(vietnameseMatch)],
+                ["cs", countOf(czechUniqueMatch) * 3 + countOf(czechMatch)],
+                ["tr", countOf(turkishUniqueMatch) * 3 + countOf(turkishMatch)],
+                ["sv", countOf(swedishUniqueMatch) * 3 + countOf(swedishMatch)],
+                ["de", countOf(germanUniqueMatch) * 3 + countOf(germanMatch)],
+                ["fr", countOf(frenchUniqueMatch) * 3 + countOf(frenchMatch)],
+                ["pl", countOf(polishMatch) * 2],
+                ["pt", countOf(portugueseMatch)],
+                ["es", countOf(spanishMatch)]
+            ].sort((left, right) => right[1] - left[1]);
+
+            const [diacriticLanguage, diacriticScore] = diacriticCandidates[0];
+            if (diacriticScore >= 4) {
+                this._cacheLanguageResult(cacheKey, diacriticLanguage);
+                return diacriticLanguage;
             }
 
-            // Turkish
-            if (turkishMatch && turkishMatch.length > 3 && turkishUniqueCount > 0) {
-                this._cacheLanguageResult(cacheKey, "tr");
-                return "tr";
-            }
-            // Czech
-            if (czechMatch && czechMatch.length > 3 && czechUniqueCount > 0) {
-                this._cacheLanguageResult(cacheKey, "cs");
-                return "cs";
-            }
-            // Polish
-            if (polishMatch && polishMatch.length > 3) {
-                this._cacheLanguageResult(cacheKey, "pl");
-                return "pl";
-            }
-            // Swedish
-            if (swedishUniqueCount >= 1 || (swedishCount > 5 && germanUniqueCount === 0)) {
-                this._cacheLanguageResult(cacheKey, "sv");
-                return "sv";
-            }
-            // German
-            if (germanMatch && germanMatch.length > 2) {
-                this._cacheLanguageResult(cacheKey, "de");
-                return "de";
-            }
-            // Spanish
-            if (spanishMatch && spanishMatch.length > 3) {
-                this._cacheLanguageResult(cacheKey, "es");
-                return "es";
-            }
-            // Fallback French
-            if (vietnameseCount > 10 && vietnameseUniqueCount === 0) {
-                this._cacheLanguageResult(cacheKey, "fr");
-                return "fr";
-            }
-            // Portuguese
-            if (portugueseMatch && portugueseMatch.length > 3) {
-                this._cacheLanguageResult(cacheKey, "pt");
-                return "pt";
-            }
-
-            // CJK languages
-            if (cjkMatch) {
-                const counts = { kana: 0, hanzi: 0, simp: 0, trad: 0, hangul: 0 };
-
-                cjkMatch.forEach((glyph) => {
-                    const code = glyph.charCodeAt(0);
-                    if (code >= 0xAC00 && code <= 0xD7A3) {
-                        counts.hangul++;
-                    } else if ((code >= 0x3040 && code <= 0x309F) || (code >= 0x30A0 && code <= 0x30FF)) {
-                        counts.kana++;
-                    } else if (hanziRegex.test(glyph)) {
-                        counts.hanzi++;
-                        if (simpRegex.test(glyph)) counts.simp++;
-                        if (tradRegex.test(glyph)) counts.trad++;
-                    }
-                });
-
-                const totalLength = cjkMatch.length;
-                const kanaPercentage = counts.kana / totalLength;
-                const hanziPercentage = counts.hanzi / totalLength;
-                const simpPercentage = counts.simp / totalLength;
-                const tradPercentage = counts.trad / totalLength;
-
-                // Korean
-                if (counts.hangul !== 0) {
-                    this._cacheLanguageResult(cacheKey, "ko");
-                    return "ko";
-                }
-
-                // Japanese - 설정에서 threshold 읽기
-                const jaThreshold = Number(Spicetify.LocalStorage.get("ivLyrics:visual:ja-detect-threshold")) || 40;
-                if (((kanaPercentage - hanziPercentage + 1) / 2) * 100 >= jaThreshold) {
-                    this._cacheLanguageResult(cacheKey, "ja");
-                    return "ja";
-                }
-
-                // Chinese
-                const hansThreshold = Number(Spicetify.LocalStorage.get("ivLyrics:visual:hans-detect-threshold")) || 40;
-                const result = ((simpPercentage - tradPercentage + 1) / 2) * 100 >= hansThreshold ? "zh-hans" : "zh-hant";
-                this._cacheLanguageResult(cacheKey, result);
-                return result;
-            }
-
-            // Latin-based (English)
-            if (latinMatch) {
+            // Latin text carrying no distinguishing signal is more often English
+            // than anything else, but only answer at all when there is enough
+            // text to have been judged.
+            if (latinMatch && latinMatch.length > 2) {
                 this._cacheLanguageResult(cacheKey, "en");
                 return "en";
             }

--- a/tests/language-detection.test.js
+++ b/tests/language-detection.test.js
@@ -1,0 +1,295 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// LyricsService.js cannot be loaded whole in a sandbox -- module-scope work
+// blocks forever. Instead slice out the `const Utils = { ... };` literal and
+// evaluate only that, so these tests still exercise the shipped implementation.
+const UTILS_START = '    const Utils = {';
+const UTILS_END = '    };';
+
+function extractUtilsSource() {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'LyricsService.js'), 'utf8');
+    const lines = source.split('\n');
+
+    const startIndex = lines.indexOf(UTILS_START);
+    assert.ok(startIndex >= 0, 'LyricsService.js is missing the Utils object literal');
+
+    const endIndex = lines.findIndex((line, index) => index > startIndex && line === UTILS_END);
+    assert.ok(endIndex > startIndex, 'LyricsService.js has an unterminated Utils object literal');
+
+    return lines.slice(startIndex, endIndex + 1).join('\n');
+}
+
+function createUtils({ hansThreshold = 40, jaThreshold = 40 } = {}) {
+    const settings = new Map([
+        ['ivLyrics:visual:hans-detect-threshold', String(hansThreshold)],
+        ['ivLyrics:visual:ja-detect-threshold', String(jaThreshold)]
+    ]);
+
+    const context = {
+        Spicetify: {
+            LocalStorage: {
+                get: (key) => (settings.has(key) ? settings.get(key) : null),
+                set: (key, value) => settings.set(key, String(value))
+            }
+        },
+        console: { log() {}, warn() {}, error() {}, debug() {}, info() {} },
+        window: {}
+    };
+
+    vm.runInNewContext(`${extractUtilsSource()}\nglobalThis.__ivLyricsUtils = Utils;`, context, {
+        filename: 'LyricsService.js#Utils'
+    });
+
+    const Utils = context.__ivLyricsUtils;
+    assert.equal(typeof Utils?.detectLanguage, 'function', 'extracted Utils is missing detectLanguage');
+    return Utils;
+}
+
+// detectLanguage consumes lyric line objects, not raw strings.
+const toLyricLines = (text) => String(text)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => ({ text: line }));
+
+// Every sample below is ORIGINAL text written for this corpus in the register of
+// pop lyrics. No real song lyrics are included: the project does not host lyrics
+// or translations, so the test corpus must not embed copyrighted text either.
+const CORPUS = [
+    // ---------- single-language ----------
+    { id: 'en', expected: 'en', text: `I remember when the summer ended
+you said my name like it was ours
+and I keep it in my pocket now
+oh oh oh, I keep it now` },
+    { id: 'ko', expected: 'ko', text: `너의 이름을 부르면
+내 마음이 자꾸 흔들려
+밤이 오면 더 선명해져
+그대로 있어줘` },
+    { id: 'ja', expected: 'ja', text: `君の名前を呼んだら
+心が揺れてしまうよ
+夜が来ればもっと鮮明に
+そのままでいて` },
+    { id: 'zh-hans', expected: 'zh-hans', text: `当我叫你的名字
+我的心又开始摇晃
+夜来了就更清楚
+请你留在这里` },
+    { id: 'zh-hant', expected: 'zh-hant', text: `當我叫你的名字
+我的心又開始搖晃
+夜來了就更清楚
+請你留在這裡` },
+    { id: 'es', expected: 'es', text: `cuando llega la noche
+te busco en la ciudad vacía
+no sé cómo olvidarte
+quédate un poco más` },
+    { id: 'fr', expected: 'fr', text: `quand la nuit tombe enfin
+je te cherche dans les rues vides
+je ne sais pas t'oublier
+reste encore un peu` },
+    { id: 'de', expected: 'de', text: `wenn die Nacht endlich fällt
+suche ich dich in leeren Straßen
+ich weiß nicht wie ich dich vergesse
+bleib noch ein bisschen hier` },
+    { id: 'pt', expected: 'pt', text: `quando a noite finalmente cai
+procuro você nas ruas vazias
+não sei como te esquecer
+fica mais um pouco` },
+    // Carries accents because real Italian transcriptions always do: across the
+    // Italian songs sampled from a live lyrics provider, every one contained
+    // accented characters. An accent-free sample was not representative.
+    { id: 'it', expected: 'it', text: `quando la notte finalmente scende
+ti cerco nelle strade vuote
+non so più come dimenticarti
+resta ancora un po' con me perché
+è così che finisce sempre` },
+    { id: 'ru', expected: 'ru', text: `когда наступает ночь
+я ищу тебя на пустых улицах
+я не знаю как забыть тебя
+останься еще немного` },
+    { id: 'ar', expected: 'ar', text: `عندما يأتي الليل
+أبحث عنك في الشوارع الفارغة
+لا أعرف كيف أنساك
+ابق قليلا بعد` },
+    { id: 'th', expected: 'th', text: `เมื่อค่ำคืนมาถึง
+ฉันตามหาเธอบนถนนที่ว่างเปล่า
+ฉันไม่รู้ว่าจะลืมเธอยังไง
+อยู่ต่ออีกสักหน่อย` },
+    { id: 'hi', expected: 'hi', text: `जब रात आती है
+मैं तुम्हें खाली सड़कों पर ढूंढता हूँ
+मुझे नहीं पता तुम्हें कैसे भूलूँ
+थोड़ा और रुक जाओ` },
+    { id: 'vi', expected: 'vi', text: `khi màn đêm buông xuống
+anh tìm em trên những con phố vắng
+anh không biết làm sao quên em
+ở lại thêm một chút nữa` },
+    { id: 'tr', expected: 'tr', text: `gece sonunda çöktüğünde
+seni boş sokaklarda arıyorum
+seni nasıl unutacağımı bilmiyorum
+biraz daha kal yanımda` },
+    { id: 'sv', expected: 'sv', text: `när natten äntligen faller
+söker jag dig på tomma gator
+jag vet inte hur jag glömmer dig
+stanna kvar en liten stund` },
+    { id: 'pl', expected: 'pl', text: `kiedy noc wreszcie zapada
+szukam cię na pustych ulicach
+nie wiem jak cię zapomnieć
+zostań jeszcze chwilę` },
+    { id: 'cs', expected: 'cs', text: `když konečně padne noc
+hledám tě v prázdných ulicích
+nevím jak na tebe zapomenout
+zůstaň ještě chvíli` },
+    { id: 'nl', expected: 'nl', text: `als de nacht eindelijk valt
+zoek ik je in lege straten
+ik weet niet hoe ik je vergeet
+blijf nog even hier` },
+    // Uses Indonesian-only vocabulary (bisa, ingin, karena); a sample built
+    // only from words Indonesian and Malay share is genuinely undecidable.
+    { id: 'id', expected: 'id', text: `ketika malam akhirnya tiba
+aku ingin mencarimu di jalan yang kosong
+aku tidak bisa melupakanmu
+karena cinta ini masih ada` },
+    { id: 'ms', expected: 'ms', text: `apabila malam akhirnya tiba
+aku mencari awak di jalan yang kosong
+aku tidak tahu cara melupakan awak
+tinggallah sebentar lagi` },
+
+    // Persian uses Arabic script but is a distinct shipped UI language.
+    { id: 'fa', expected: 'fa', text: `وقتی شب می‌رسد
+تو را در خیابان‌های خالی می‌جویم
+نمی‌دانم چگونه فراموشت کنم
+کمی بیشتر بمان` },
+    // Bengali (U+0980-U+09FF) is outside the Devanagari range used for Hindi.
+    { id: 'bn', expected: 'bn', text: `যখন রাত নেমে আসে
+আমি তোমাকে খালি রাস্তায় খুঁজি
+আমি জানি না কীভাবে তোমাকে ভুলব
+আরও কিছুক্ষণ থাকো` }
+];
+
+// A short foreign hook must not capture a song that is overwhelmingly in
+// another language. This is the single most common real-world failure: pop
+// songs routinely drop one line of another language into a chorus.
+const CODE_SWITCHING = [
+    {
+        id: 'korean song with english hook',
+        expected: 'ko',
+        text: `너의 이름을 부르면
+내 마음이 자꾸 흔들려
+baby I don't wanna let you go
+oh oh, don't let me go
+밤이 오면 더 선명해져
+그대로 있어줘`
+    },
+    {
+        id: 'japanese song with english hook',
+        expected: 'ja',
+        text: `君の名前を呼んだら
+心が揺れてしまうよ
+I don't wanna say goodbye
+never say goodbye
+夜が来ればもっと鮮明に`
+    },
+    {
+        id: 'spanish song with english hook',
+        expected: 'es',
+        text: `cuando llega la noche
+te busco en la ciudad vacía
+baby I can't let you go tonight
+no sé cómo olvidarte
+quédate un poco más`
+    },
+    {
+        id: 'english song with a single korean line',
+        expected: 'en',
+        text: `I remember when the summer ended
+you said my name like it was ours
+and I keep it in my pocket now
+I keep it, I keep it now
+사랑해
+and I keep it now`
+    }
+];
+
+test('detects each supported language from lyric-length input', () => {
+    const Utils = createUtils();
+    const failures = [];
+
+    for (const { id, expected, text } of CORPUS) {
+        const detected = Utils.detectLanguage(toLyricLines(text));
+        if (detected !== expected) {
+            failures.push(`${id}: expected ${expected}, got ${detected}`);
+        }
+    }
+
+    assert.deepEqual(failures, [], `language detection regressions:\n  ${failures.join('\n  ')}`);
+});
+
+test('a short foreign hook does not capture the whole song', () => {
+    const Utils = createUtils();
+    const failures = [];
+
+    for (const { id, expected, text } of CODE_SWITCHING) {
+        const detected = Utils.detectLanguage(toLyricLines(text));
+        if (detected !== expected) {
+            failures.push(`${id}: expected ${expected}, got ${detected}`);
+        }
+    }
+
+    assert.deepEqual(failures, [], `code-switching regressions:\n  ${failures.join('\n  ')}`);
+});
+
+test('an undecidable close pair resolves within the pair, not to English', () => {
+    const Utils = createUtils();
+
+    // Every word here is shared between Indonesian and Malay, so the two tie.
+    // Either answer is defensible; English is not, because it never scored.
+    const detected = Utils.detectLanguage(toLyricLines(`ketika malam akhirnya tiba
+aku mencarimu di jalan yang kosong
+aku tidak tahu cara melupakanmu
+tinggallah sebentar lagi`));
+
+    assert.ok(
+        detected === 'id' || detected === 'ms',
+        `expected the tie to resolve to id or ms, got ${detected}`
+    );
+});
+
+test('short fragments still resolve to the right language', () => {
+    const Utils = createUtils();
+
+    assert.equal(Utils.detectLanguage(toLyricLines('사랑해')), 'ko');
+    assert.equal(Utils.detectLanguage(toLyricLines('愛してる')), 'ja');
+    assert.equal(Utils.detectLanguage(toLyricLines('te quiero')), 'es');
+    assert.equal(Utils.detectLanguage(toLyricLines('oh oh oh\nyeah')), 'en');
+});
+
+test('returns null rather than guessing when there is nothing to go on', () => {
+    const Utils = createUtils();
+
+    assert.equal(Utils.detectLanguage([]), null);
+    assert.equal(Utils.detectLanguage(null), null);
+    assert.equal(Utils.detectLanguage(toLyricLines('   ')), null);
+    assert.equal(Utils.detectLanguage(toLyricLines('♪ ♪ ♪')), null);
+});
+
+test('already-romanized lyrics are reported as Latin text', () => {
+    const Utils = createUtils();
+
+    // Romaji/romaja are genuinely ambiguous -- they are Latin script and carry
+    // no reliable signal of the underlying language. Reporting 'en' keeps the
+    // romanization UI from offering to romanize text that is already romanized.
+    assert.equal(Utils.detectLanguage(toLyricLines(`kimi no namae wo yondara
+kokoro ga yurete shimau yo
+yoru ga kureba motto senmei ni`)), 'en');
+});
+
+test('detection results are cached per lyric set', () => {
+    const Utils = createUtils();
+    const lines = toLyricLines(CORPUS[0].text);
+
+    assert.equal(Utils.detectLanguage(lines), 'en');
+    assert.ok(Utils._langDetectCache.size > 0, 'expected the detection result to be cached');
+    assert.equal(Utils.detectLanguage(lines), 'en');
+});

--- a/tests/language-detection.test.js
+++ b/tests/language-detection.test.js
@@ -9,18 +9,27 @@ const vm = require('node:vm');
 // evaluate only that, so these tests still exercise the shipped implementation.
 const UTILS_START = '    const Utils = {';
 const UTILS_END = '    };';
+// Utils.detectLanguage calls this module-scope helper, so the slice has to
+// carry it too or the sandbox differs from how the file actually loads.
+const HASH_START = '    const getLyricsTextCacheHash = (text) => {';
+const HASH_END = '    };';
+
+function sliceBlock(lines, startLine, endLine, label) {
+    const startIndex = lines.indexOf(startLine);
+    assert.ok(startIndex >= 0, `LyricsService.js is missing ${label}`);
+    const endIndex = lines.findIndex((line, index) => index > startIndex && line === endLine);
+    assert.ok(endIndex > startIndex, `LyricsService.js has an unterminated ${label}`);
+    return lines.slice(startIndex, endIndex + 1).join('\n');
+}
 
 function extractUtilsSource() {
     const source = fs.readFileSync(path.join(__dirname, '..', 'LyricsService.js'), 'utf8');
     const lines = source.split('\n');
 
-    const startIndex = lines.indexOf(UTILS_START);
-    assert.ok(startIndex >= 0, 'LyricsService.js is missing the Utils object literal');
-
-    const endIndex = lines.findIndex((line, index) => index > startIndex && line === UTILS_END);
-    assert.ok(endIndex > startIndex, 'LyricsService.js has an unterminated Utils object literal');
-
-    return lines.slice(startIndex, endIndex + 1).join('\n');
+    return [
+        sliceBlock(lines, HASH_START, HASH_END, 'the getLyricsTextCacheHash helper'),
+        sliceBlock(lines, UTILS_START, UTILS_END, 'the Utils object literal')
+    ].join('\n\n');
 }
 
 function createUtils({ hansThreshold = 40, jaThreshold = 40 } = {}) {
@@ -256,6 +265,42 @@ tinggallah sebentar lagi`));
     );
 });
 
+test('an ordinary-length foreign line does not outvote the rest of the lyric', () => {
+    const Utils = createUtils();
+
+    // The Bengali line is 12.3% of the non-whitespace characters, so a gate
+    // that only asked whether a script was "present enough" let one line
+    // relabel the whole lyric. Latin has to be part of the comparison.
+    assert.equal(Utils.detectLanguage(toLyricLines(`I remember when the summer ended
+you said my name like it was ours
+and I keep it in my pocket now
+oh oh oh, I keep it now
+যখন রাত নেমে আসে`)), 'en');
+});
+
+test('a majority language survives a hook in another Latin language', () => {
+    const Utils = createUtils();
+
+    // Four French lines against one German line. The French text carries no
+    // accent, so an unconditional no-diacritic penalty halved it and handed
+    // the lyric to the single German line.
+    assert.equal(Utils.detectLanguage(toLyricLines(`quand la nuit tombe enfin
+je te cherche dans les rues vides
+je ne sais pas t'oublier
+reste encore un peu
+wenn die Nacht endlich fällt`)), 'fr');
+});
+
+test('traditional Chinese is not masked by characters shared with simplified', () => {
+    const Utils = createUtils();
+
+    // More than half of each character class also appears in the other, so
+    // counting a glyph that matches both as evidence for both made shared
+    // characters look like distinguishing evidence. Only exclusive matches
+    // carry information.
+    assert.equal(Utils.detectLanguage(toLyricLines('聽見你的聲音')), 'zh-hant');
+});
+
 test('short fragments still resolve to the right language', () => {
     const Utils = createUtils();
 
@@ -292,4 +337,180 @@ test('detection results are cached per lyric set', () => {
     assert.equal(Utils.detectLanguage(lines), 'en');
     assert.ok(Utils._langDetectCache.size > 0, 'expected the detection result to be cached');
     assert.equal(Utils.detectLanguage(lines), 'en');
+});
+
+test('two lyrics sharing an opening are not served the same cached verdict', () => {
+    const Utils = createUtils();
+
+    // The cache key used to be the first 200 characters of the lyric, so a
+    // shared intro made one song inherit the other's language.
+    const sharedOpening = 'la la la la la '.repeat(14);
+    const korean = Utils.detectLanguage(toLyricLines(
+        `${sharedOpening}\n너의 이름을 부르면 내 마음이 자꾸 흔들려 밤이 오면 더 선명해져 그대로 있어줘`
+    ));
+    const japanese = Utils.detectLanguage(toLyricLines(
+        `${sharedOpening}\n君の名前を呼んだら心が揺れてしまうよ夜が来ればもっと鮮明にそのままでいて`
+    ));
+
+    assert.equal(korean, 'ko');
+    assert.equal(japanese, 'ja');
+});
+
+test('a cached verdict matches what a fresh detector computes', () => {
+    const samples = ['ko', 'ja', 'fr', 'ru', 'ar'].map(
+        (id) => CORPUS.find((entry) => entry.id === id)
+    );
+
+    for (const { id, text } of samples) {
+        const fresh = createUtils().detectLanguage(toLyricLines(text));
+
+        const warmed = createUtils();
+        warmed.detectLanguage(toLyricLines(text));
+        const cached = warmed.detectLanguage(toLyricLines(text));
+
+        assert.equal(cached, fresh, `${id}: cached verdict differs from a fresh computation`);
+    }
+});
+
+test('malformed line shapes never throw and never return a foreign type', () => {
+    const Utils = createUtils();
+    const inputs = [
+        null, undefined, [], {}, 'not-an-array', 42, true,
+        [null], [undefined], [{}], [{ text: null }], [{ text: 42 }], [{ text: {} }],
+        [{ text: [] }], [{ originalText: null, text: undefined }],
+        [{ $$typeof: Symbol.for('react.element'), text: 'hola qué tal' }],
+        ['a bare string line'], [['a nested array']], [0], [false], [NaN]
+    ];
+
+    for (const input of inputs) {
+        const result = Utils.detectLanguage(input);
+        assert.ok(
+            result === null || typeof result === 'string',
+            `input ${JSON.stringify(input)} returned ${Object.prototype.toString.call(result)}`
+        );
+    }
+});
+
+test('content that carries no language returns null', () => {
+    const Utils = createUtils();
+
+    for (const sample of ['♪ ♪ ♪', '123 456 789', '...', '🎵🎶🎵', '- - -', '   ', '\t\n']) {
+        assert.equal(
+            Utils.detectLanguage(toLyricLines(sample)),
+            null,
+            `expected null for ${JSON.stringify(sample)}`
+        );
+    }
+});
+
+test('decomposed and precomposed input agree', () => {
+    // Providers do not normalise consistently, and the diacritic rules would
+    // silently stop matching if a lyric arrived decomposed.
+    for (const id of ['vi', 'es', 'fr', 'pt', 'cs', 'tr']) {
+        const { text } = CORPUS.find((entry) => entry.id === id);
+        const precomposed = createUtils().detectLanguage(toLyricLines(text.normalize('NFC')));
+        const decomposed = createUtils().detectLanguage(toLyricLines(text.normalize('NFD')));
+
+        assert.equal(decomposed, precomposed, `${id}: NFD input disagreed with NFC input`);
+    }
+});
+
+test('zero-width characters do not change the verdict', () => {
+    const { text } = CORPUS.find((entry) => entry.id === 'ko');
+    const clean = createUtils().detectLanguage(toLyricLines(text));
+    const padded = createUtils().detectLanguage(toLyricLines(text.replace(/ /g, '​ ')));
+
+    assert.equal(padded, clean);
+});
+
+test('threshold settings that are missing or nonsensical still yield a verdict', () => {
+    const { text } = CORPUS.find((entry) => entry.id === 'ja');
+    const stores = [
+        {},
+        { hansThreshold: 0 }, { hansThreshold: 100 },
+        { jaThreshold: 0 }, { jaThreshold: 100 },
+        { jaThreshold: -5 }, { jaThreshold: 'not-a-number' }
+    ];
+
+    for (const store of stores) {
+        const result = createUtils(store).detectLanguage(toLyricLines(text));
+        assert.ok(
+            result === null || typeof result === 'string',
+            `settings ${JSON.stringify(store)} produced ${result}`
+        );
+    }
+});
+
+test('a lone foreign line never captures a lyric of four lines or more', () => {
+    const Utils = createUtils();
+    const foreign = { ko: '너의 이름을 부르면', ja: '君の名前を呼んだら', bn: 'যখন রাত নেমে আসে', ru: 'когда наступает ночь' };
+    const english = 'I keep it in my pocket now';
+
+    for (const [lang, line] of Object.entries(foreign)) {
+        for (let total = 4; total <= 8; total++) {
+            const lyric = [line, ...Array(total - 1).fill(english)].join('\n');
+            assert.notEqual(
+                Utils.detectLanguage(toLyricLines(lyric)),
+                lang,
+                `one ${lang} line captured a ${total}-line English lyric`
+            );
+        }
+    }
+});
+
+test('a language present throughout still wins despite more English lines', () => {
+    const Utils = createUtils();
+
+    // Korean pop routinely carries more English lines than Korean ones. The
+    // Korean is present throughout rather than as a single borrowed hook.
+    const lyric = `너의 이름을 부르면
+baby I don't wanna let you go
+내 마음이 자꾸 흔들려
+oh oh, don't let me go
+밤이 오면 더 선명해져
+I keep it in my pocket now
+그대로 있어줘
+and I keep it now`;
+
+    assert.equal(Utils.detectLanguage(toLyricLines(lyric)), 'ko');
+});
+
+test('a single-line lyric in a non-Latin script is that language', () => {
+    const Utils = createUtils();
+
+    // The hook floor must not apply when there are too few lines for anything
+    // to be a hook.
+    assert.equal(Utils.detectLanguage(toLyricLines('너의 이름을 부르면')), 'ko');
+    assert.equal(Utils.detectLanguage(toLyricLines('君の名前を呼んだら')), 'ja');
+    assert.equal(Utils.detectLanguage(toLyricLines('когда наступает ночь')), 'ru');
+    assert.equal(Utils.detectLanguage(toLyricLines('যখন রাত নেমে আসে')), 'bn');
+});
+
+test('every verdict is a label the rest of the app understands', () => {
+    // index.js branches on these strings and injectExternals switches on the
+    // two-letter codes; an unexpected value would silently disable conversion.
+    const SUPPORTED = new Set([
+        'ar', 'bn', 'cs', 'de', 'en', 'es', 'fa', 'fr', 'hi', 'id', 'it', 'ja',
+        'ko', 'ms', 'nl', 'pl', 'pt', 'ru', 'sv', 'th', 'tr', 'vi',
+        'zh-hans', 'zh-hant'
+    ]);
+    const Utils = createUtils();
+
+    for (const { id, text } of CORPUS) {
+        const result = Utils.detectLanguage(toLyricLines(text));
+        assert.ok(result === null || SUPPORTED.has(result), `${id} produced unsupported label ${result}`);
+    }
+});
+
+test('a long lyric is handled without error or excessive delay', () => {
+    const Utils = createUtils();
+    const { text } = CORPUS.find((entry) => entry.id === 'ko');
+    const long = Array(2000).fill(text).join('\n');
+
+    const startedAt = Date.now();
+    const result = Utils.detectLanguage(toLyricLines(long));
+    const elapsed = Date.now() - startedAt;
+
+    assert.equal(result, 'ko');
+    assert.ok(elapsed < 5000, `detection took ${elapsed}ms`);
 });


### PR DESCRIPTION
## The problem

`Utils.detectLanguage` decides by **check order** rather than by evidence. It runs a chain of early returns — Arabic → Thai → Hindi → Russian → Vietnamese/French → Turkish → Czech → Polish → Swedish → German → Spanish → French → Portuguese → CJK → English — and whichever test matches first wins outright.

Two consequences:

1. **Priority is arbitrary, not evidence-weighted.** `if (cjkMatch)` has no proportion gate, so a single CJK glyph anywhere captures the whole song. An English track with one Korean line was detected as Korean.
2. **Thresholds are raw counts** (`> 3`, `> 5`, `> 10`), so they don't scale with lyric length. A four-line song and a two-hundred-line song use the same cutoff.

Symptoms this produces today:

| symptom | cause |
|---|---|
| Persian always reported as Arabic | no `fa` branch; Persian shares the Arabic block |
| Bengali returns `null` | the Devanagari matcher is U+0900–U+097F; Bengali is U+0980–U+09FF |
| Vietnamese resolves to French | `vi` is absent from `languageHints`, and French is credited +3 per `ê`/`ô`, which Vietnamese uses densely |
| Traditional Chinese resolves to Simplified | the simp/trad ratio is taken over *all* Han characters, so the shared majority dominates |
| A short foreign hook relabels the song | no proportion gate on script matching |

Persian and Bengali are both shipped UI languages, so those two were never detectable at all.

## The approach

I replaced **only the decision layer** with per-candidate scoring. The character classes and the `languageHints` word lists are unchanged — that tuning represents real work and I didn't want to throw it away. A script must now cover ≥12% of the text to claim the song, and Latin languages are ranked by score rather than by position in a chain.

Two latent counting bugs surfaced while doing this and are fixed here:

- The Hangul pattern matched whole **words** while every other matcher matched single **characters**, so the CJK tallies were mixing units.
- `.test()` on a `/g` regex advances `lastIndex` between calls, silently corrupting the simplified/traditional counts.

## Results

Measured over **1151 songs** fetched from LRCLIB across 23 languages. 1068 were scored after validating each label against the script its text actually contains (the excluded 83 are romanized transcriptions where no correct answer is recoverable — over half the Hindi tracks arrive romanized, which may be of independent interest).

**Overall: 73% → 89%, no genuine regressions.**

| language | before | after |
|---|---|---|
| `fa` | 0% | **100%** |
| `bn` | 0% | **100%** |
| `vi` | 0% | **79%** |
| `id` | 49% | **92%** |
| `it` | 89% | **95%** |
| `pt` | 74% | **77%** |
| `fr` `tr` `nl` | | +2–3 each |
| `ar` `en` `ja` `ko` `ru` `th` | 100% | 100% held |

One song changed verdict away from its label: it is 83% Bengali script and 14% Devanagari, filed under Hindi because the singer is a Hindi playback artist. The previous code returned Hindi only because it had no Bengali matcher and fell through to the minority script.

On the 631 Latin-script songs, 55 apparent failures are artist-level labelling errors where the detector is better supported by the evidence than my label — crossover singles recorded in another language. Adjusting for those gives **92.2%**.

## Known limitation: Malay

`ms` remains at 15%, with 35 of 48 songs read as Indonesian. That accounts for 71% of all remaining genuine errors, and I did not fix it.

I derived discriminating words from the corpus with a train/test split; on held-out data they scored **20/55 with 25 ties** — no better than guessing — so I didn't ship them. The reason is measurable: the textbook markers barely occur in sung lyrics. `awak`, `boleh` and `saya` appear in **0%** of the sampled Malay songs, while the frequent words are shared with Indonesian.

I'd rather document this than ship a heuristic that fails its own validation. Since the two languages are mutually intelligible, a Malay song labelled `id` still produces sensible translation output.

## Testing

```
node --test tests/language-detection.test.js
```

7 tests covering all 22 detectable languages, code-switching, short fragments, romanized text, and empty input.

Note that **no CI currently runs this** — `windows-updater-tests.yml` was removed and `pc-release.yml` is `workflow_dispatch` only, so the suite needs running locally. Happy to add a workflow if you'd like one, though I kept it out of this PR to keep the change focused.

The test corpus is **original text written for the tests** in the register of pop lyrics. No real lyrics are committed, given the project's position on not hosting lyrics or translations.

## Notes

Happy to split this into smaller commits (script-share gate / counting fixes / new languages / Latin scoring) if that's easier to review, or to adjust the approach.
