### PR TITLE
Support sync creator benefits

### DIFF
--- a/Pages.js
+++ b/Pages.js
@@ -34,8 +34,59 @@ function getCreatorProfileCopy() {
 		artistGroups: I18n.t("creatorProfile.artistGroups") || "Artist Groups",
 		noArtistStats: I18n.t("creatorProfile.noArtistStats") || "No artist stats yet.",
 		clearArtistFilter: I18n.t("creatorProfile.clearArtistFilter") || "Clear artist filter",
-		filteredArtist: I18n.t("creatorProfile.filteredArtist") || "Filtered artist"
+		filteredArtist: I18n.t("creatorProfile.filteredArtist") || "Filtered artist",
+		supporter: I18n.t("creatorProfile.supporter") || "Supporter",
+		monthlySupporter: I18n.t("creatorProfile.monthlySupporter") || "Monthly Supporter",
+		nicknameStyle: I18n.t("creatorProfile.nicknameStyle") || "Nickname style",
+		nicknameStyleDesc: I18n.t("creatorProfile.nicknameStyleDesc") || "This color is used for your name in the sync creator credit below the lyrics.",
+		solid: I18n.t("creatorProfile.solid") || "Solid",
+		gradient: I18n.t("creatorProfile.gradient") || "Gradient",
+		solidColor: I18n.t("creatorProfile.solidColor") || "Solid color",
+		gradientStart: I18n.t("creatorProfile.gradientStart") || "Start color",
+		gradientEnd: I18n.t("creatorProfile.gradientEnd") || "End color",
+		gradientAngle: I18n.t("creatorProfile.gradientAngle") || "Gradient angle",
+		decorationPreview: I18n.t("creatorProfile.decorationPreview") || "Preview",
+		saveDecoration: I18n.t("creatorProfile.saveDecoration") || "Save color",
+		resetDecoration: I18n.t("creatorProfile.resetDecoration") || "Reset to default",
+		refreshSupportRole: I18n.t("creatorProfile.refreshSupportRole") || "Refresh supporter role",
+		supportRoleNotFound: I18n.t("creatorProfile.supportRoleNotFound") || "No supporter role was found. Refresh after your Discord role is assigned.",
+		monthlyOnlyGradient: I18n.t("creatorProfile.monthlyOnlyGradient") || "Gradients are available to Monthly Supporters only.",
+		decorationSaved: I18n.t("creatorProfile.decorationSaved") || "Nickname color saved.",
+		decorationReset: I18n.t("creatorProfile.decorationReset") || "Nickname color reset.",
+		decorationSaveFailed: I18n.t("creatorProfile.decorationSaveFailed") || "Failed to save nickname color.",
+		supportRoleRefreshFailed: I18n.t("creatorProfile.supportRoleRefreshFailed") || "Failed to refresh supporter role."
 	};
+}
+
+function getSupportBadgeLabel(tier, copy = getCreatorProfileCopy()) {
+	if (tier === "monthly") return copy.monthlySupporter;
+	if (tier === "supporter") return copy.supporter;
+	return "";
+}
+
+function getEffectiveCreatorDecoration(tier, decoration) {
+	if ((tier !== "supporter" && tier !== "monthly") || !decoration) {
+		return null;
+	}
+	if (tier === "monthly" && decoration.mode === "gradient") {
+		return { ...decoration, mode: "gradient" };
+	}
+	return { ...decoration, mode: "solid" };
+}
+
+function getCreatorDecorationStyle(tier, decoration) {
+	const effective = getEffectiveCreatorDecoration(tier, decoration);
+	if (!effective) return null;
+	if (effective.mode === "gradient") {
+		return {
+			backgroundImage: `linear-gradient(${Number(effective.gradientAngle) || 0}deg, ${effective.gradientStartColor}, ${effective.gradientEndColor})`,
+			WebkitBackgroundClip: "text",
+			backgroundClip: "text",
+			WebkitTextFillColor: "transparent",
+			color: effective.gradientStartColor
+		};
+	}
+	return { color: effective.solidColor };
 }
 
 function mergeCreatorProfileContributions(currentItems, nextItems) {
@@ -565,6 +616,144 @@ function createCreatorProfileShell(contributor, options = {}) {
 	};
 }
 
+const CreatorDecorationEditor = react.memo(({
+	displayName,
+	tier,
+	decoration,
+	pending,
+	onSave,
+	onReset,
+	onRefresh
+}) => {
+	const copy = getCreatorProfileCopy();
+	const defaults = Utils.getCreatorDecorationDefaults();
+	const source = decoration ? { ...defaults, ...decoration } : defaults;
+	const [draft, setDraft] = react.useState(source);
+	const [notice, setNotice] = react.useState("");
+
+	react.useEffect(() => {
+		setDraft(decoration ? { ...defaults, ...decoration } : defaults);
+		setNotice("");
+	}, [decoration?.mode, decoration?.solidColor, decoration?.gradientStartColor, decoration?.gradientEndColor, decoration?.gradientAngle, tier]);
+
+	if (tier !== "supporter" && tier !== "monthly") {
+		return null;
+	}
+
+	const previewDecoration = {
+		...draft,
+		mode: tier === "monthly" ? draft.mode : "solid"
+	};
+	const previewStyle = getCreatorDecorationStyle(tier, previewDecoration) || {};
+	const chooseMode = (mode) => {
+		if (mode === "gradient" && tier !== "monthly") {
+			setNotice(copy.monthlyOnlyGradient);
+			Toast.warning(copy.monthlyOnlyGradient);
+			return;
+		}
+		setNotice("");
+		setDraft((current) => ({ ...current, mode }));
+	};
+
+	const colorField = (label, key) => react.createElement(
+		"label",
+		{ className: "lyrics-creator-decoration-field" },
+		react.createElement("span", null, label),
+		react.createElement(
+			"span",
+			{ className: "lyrics-creator-decoration-color-control" },
+			react.createElement("input", {
+				type: "color",
+				value: draft[key],
+				disabled: pending,
+				onChange: (event) => setDraft((current) => ({ ...current, [key]: event.currentTarget.value.toUpperCase() }))
+			}),
+			react.createElement("code", null, draft[key])
+		)
+	);
+
+	return react.createElement(
+		"section",
+		{ className: "lyrics-creator-decoration-editor", "aria-label": copy.nicknameStyle },
+		react.createElement(
+			"div",
+			{ className: "lyrics-creator-decoration-heading" },
+			react.createElement(
+				"div",
+				null,
+				react.createElement("h3", null, copy.nicknameStyle),
+				react.createElement("p", null, copy.nicknameStyleDesc)
+			),
+			react.createElement("span", { className: `lyrics-creator-support-badge is-${tier}` }, getSupportBadgeLabel(tier, copy))
+		),
+		react.createElement(
+			"div",
+			{ className: "lyrics-creator-decoration-modes" },
+			react.createElement("button", {
+				type: "button",
+				className: draft.mode === "solid" || tier !== "monthly" ? "is-active" : "",
+				"aria-pressed": draft.mode === "solid" || tier !== "monthly",
+				disabled: pending,
+				onClick: () => chooseMode("solid")
+			}, copy.solid),
+			react.createElement("button", {
+				type: "button",
+				className: `${draft.mode === "gradient" && tier === "monthly" ? "is-active" : ""} ${tier !== "monthly" ? "is-locked" : ""}`.trim(),
+				"aria-pressed": draft.mode === "gradient" && tier === "monthly",
+				"aria-describedby": tier !== "monthly" ? "lyrics-creator-decoration-notice" : undefined,
+				disabled: pending,
+				onClick: () => chooseMode("gradient")
+			}, `${copy.gradient}${tier !== "monthly" ? ` · ${copy.monthlySupporter}` : ""}`)
+		),
+		react.createElement("div", {
+			id: "lyrics-creator-decoration-notice",
+			className: "lyrics-creator-decoration-notice",
+			role: "status",
+			"aria-live": "polite",
+			hidden: !notice
+		}, notice),
+		draft.mode === "gradient" && tier === "monthly"
+			? react.createElement(
+				"div",
+				{ className: "lyrics-creator-decoration-fields" },
+				colorField(copy.gradientStart, "gradientStartColor"),
+				colorField(copy.gradientEnd, "gradientEndColor"),
+				react.createElement(
+					"label",
+					{ className: "lyrics-creator-decoration-field" },
+					react.createElement("span", null, `${copy.gradientAngle} · ${draft.gradientAngle}°`),
+					react.createElement("input", {
+						type: "range",
+						min: 0,
+						max: 360,
+						value: draft.gradientAngle,
+						disabled: pending,
+						onChange: (event) => setDraft((current) => ({ ...current, gradientAngle: Number(event.currentTarget.value) }))
+					})
+				)
+			)
+			: react.createElement("div", { className: "lyrics-creator-decoration-fields" }, colorField(copy.solidColor, "solidColor")),
+		react.createElement(
+			"div",
+			{ className: "lyrics-creator-decoration-preview" },
+			react.createElement("span", { className: "lyrics-creator-decoration-preview-label" }, copy.decorationPreview),
+			react.createElement("strong", { style: previewStyle }, displayName)
+		),
+		react.createElement(
+			"div",
+			{ className: "lyrics-creator-decoration-actions" },
+			react.createElement("button", { type: "button", disabled: pending, onClick: onRefresh }, copy.refreshSupportRole),
+			react.createElement("button", { type: "button", disabled: pending, onClick: onReset }, copy.resetDecoration),
+			react.createElement("button", {
+				type: "button",
+				className: "is-primary",
+				disabled: pending,
+				onClick: () => onSave({ ...draft, mode: tier === "monthly" ? draft.mode : "solid" })
+			}, pending ? "..." : copy.saveDecoration)
+		)
+	);
+});
+
 const SyncCreatorProfileModal = react.memo(({
 	contributor,
 	profile,
@@ -580,7 +769,12 @@ const SyncCreatorProfileModal = react.memo(({
 	onLoadMore,
 	onTrackClick,
 	activeArtistFilter,
-	onArtistFilterChange
+	onArtistFilterChange,
+	supportInfo,
+	decorationPending,
+	onSaveDecoration,
+	onResetDecoration,
+	onRefreshSupport
 }) => {
 	const copy = getCreatorProfileCopy();
 	const [uiTheme, setUiTheme] = react.useState(getCreatorProfileUiTheme);
@@ -618,6 +812,8 @@ const SyncCreatorProfileModal = react.memo(({
 	const showGreetingTranslationStatus = greetingTranslationStatus === "loading" && !!rawGreeting.trim();
 	const canEditGreeting = isOwnProfile && typeof onSaveGreeting === "function";
 	const publicProfileUrl = getCreatorPublicProfileUrl(profileData, contributor);
+	const supportTier = supportInfo?.tier || "none";
+	const supportBadgeLabel = getSupportBadgeLabel(supportTier, copy);
 	const likeButtonLabel = likePending ? "..." : liked ? copy.liked : copy.like;
 	const likeButtonTitle = !profileData.viewer?.authenticated && !isOwnProfile
 		? copy.likeLoginRequired
@@ -793,7 +989,12 @@ const SyncCreatorProfileModal = react.memo(({
 					react.createElement(
 						"div",
 						{ className: "lyrics-creator-profile-title-block" },
-						react.createElement("h2", { className: "lyrics-creator-profile-name" }, displayName),
+						react.createElement(
+							"div",
+							{ className: "lyrics-creator-profile-name-with-badge" },
+							react.createElement("h2", { className: "lyrics-creator-profile-name" }, displayName),
+							supportBadgeLabel && react.createElement("span", { className: `lyrics-creator-support-badge is-${supportTier}` }, supportBadgeLabel)
+						),
 						subtitle && react.createElement("div", { className: "lyrics-creator-profile-handle" }, subtitle)
 					),
 				react.createElement(
@@ -825,6 +1026,40 @@ const SyncCreatorProfileModal = react.memo(({
 					)
 				)
 				),
+			isOwnProfile && (supportTier !== "none"
+				? react.createElement(CreatorDecorationEditor, {
+					displayName,
+					tier: supportTier,
+					decoration: supportInfo?.decoration || null,
+					pending: decorationPending,
+					onSave: onSaveDecoration,
+					onReset: onResetDecoration,
+					onRefresh: onRefreshSupport
+				})
+				: react.createElement(
+					"section",
+					{ className: "lyrics-creator-decoration-editor is-role-missing", "aria-label": copy.nicknameStyle },
+					react.createElement(
+						"div",
+						{ className: "lyrics-creator-decoration-heading" },
+						react.createElement(
+							"div",
+							null,
+							react.createElement("h3", null, copy.nicknameStyle),
+							react.createElement("p", null, copy.supportRoleNotFound)
+						),
+						react.createElement(
+							"button",
+							{
+								type: "button",
+								className: "lyrics-creator-decoration-refresh-role",
+								disabled: decorationPending,
+								onClick: onRefreshSupport
+							},
+							copy.refreshSupportRole
+						)
+					)
+				)),
 			(greeting || canEditGreeting) && react.createElement(
 				"div",
 				{ className: "lyrics-creator-profile-greeting-block" },
@@ -1138,6 +1373,10 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 		() => getDisplayContributors(contributors, 3, copy.anonymous),
 		[contributors, copy.anonymous]
 	);
+	const visibleContributorSignature = useMemo(
+		() => visibleContributors.map((contributor) => contributor.userHash || contributor.key).join("|"),
+		[visibleContributors]
+	);
 	const [activeContributor, setActiveContributor] = useState(null);
 	const [creatorProfile, setCreatorProfile] = useState(null);
 	const [profileLoading, setProfileLoading] = useState(false);
@@ -1147,8 +1386,41 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 	const [profileLoadingMore, setProfileLoadingMore] = useState(false);
 	const [profileListRefreshing, setProfileListRefreshing] = useState(false);
 	const [profileArtistFilter, setProfileArtistFilter] = useState(null);
+	const [supportByUserHash, setSupportByUserHash] = useState({});
+	const [decorationPending, setDecorationPending] = useState(false);
 	const requestIdRef = useRef(0);
 	const greetingTranslationRequestIdRef = useRef(0);
+
+	useEffect(() => {
+		const discordIds = visibleContributors
+			.filter((contributor) => contributor.linked && Utils.isDiscordUserHash(contributor.userHash))
+			.map((contributor) => contributor.userHash);
+		if (!discordIds.length) return undefined;
+
+		let cancelled = false;
+		Promise.all([
+			Utils.fetchCreatorDecorations(discordIds).catch(() => ({})),
+			Promise.all(discordIds.map(async (userHash) => {
+				try {
+					return [userHash, await Utils.fetchDiscordSupportTier(userHash)];
+				} catch (error) {
+					console.warn("[ivLyrics] Failed to load supporter role:", error);
+					return [userHash, "none"];
+				}
+			}))
+		]).then(([decorations, tiers]) => {
+			if (cancelled) return;
+			setSupportByUserHash((current) => {
+				const next = { ...current };
+				for (const [userHash, tier] of tiers) {
+					next[userHash] = { tier, decoration: decorations[userHash] || null };
+				}
+				return next;
+			});
+		});
+
+		return () => { cancelled = true; };
+	}, [visibleContributorSignature]);
 
 	const closeProfile = useCallback(() => {
 		requestIdRef.current += 1;
@@ -1479,6 +1751,68 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 		}
 	}, [copy.greetingSaveFailed, copy.greetingSaveSuccess, creatorProfile, loadCreatorGreetingTranslation]);
 
+	const handleSaveDecoration = useCallback(async (decoration) => {
+		if (!activeContributor?.userHash) return;
+		setDecorationPending(true);
+		try {
+			const result = await Utils.saveOwnCreatorDecoration(decoration);
+			Utils.setCachedDiscordSupportTier(activeContributor.userHash, result.tier);
+			setSupportByUserHash((current) => ({
+				...current,
+				[activeContributor.userHash]: { tier: result.tier, decoration: result.decoration }
+			}));
+			Toast.success(copy.decorationSaved);
+		} catch (error) {
+			const message = error?.code === "monthly_supporter_required"
+				? copy.monthlyOnlyGradient
+				: error?.code === "supporter_required"
+					? copy.supportRoleNotFound
+					: copy.decorationSaveFailed;
+			Toast.error(message);
+		} finally {
+			setDecorationPending(false);
+		}
+	}, [activeContributor, copy.decorationSaveFailed, copy.decorationSaved]);
+
+	const handleResetDecoration = useCallback(async () => {
+		if (!activeContributor?.userHash) return;
+		setDecorationPending(true);
+		try {
+			await Utils.resetOwnCreatorDecoration();
+			setSupportByUserHash((current) => ({
+				...current,
+				[activeContributor.userHash]: {
+					tier: current[activeContributor.userHash]?.tier || "none",
+					decoration: null
+				}
+			}));
+			Toast.success(copy.decorationReset);
+		} catch (error) {
+			Toast.error(error?.message || copy.decorationSaveFailed);
+		} finally {
+			setDecorationPending(false);
+		}
+	}, [activeContributor, copy.decorationReset, copy.decorationSaveFailed]);
+
+	const handleRefreshSupport = useCallback(async () => {
+		if (!activeContributor?.userHash) return;
+		setDecorationPending(true);
+		try {
+			const tier = await Utils.fetchDiscordSupportTier(activeContributor.userHash, { forceRefresh: true });
+			setSupportByUserHash((current) => ({
+				...current,
+				[activeContributor.userHash]: {
+					tier,
+					decoration: current[activeContributor.userHash]?.decoration || null
+				}
+			}));
+		} catch (error) {
+			Toast.error(copy.supportRoleRefreshFailed);
+		} finally {
+			setDecorationPending(false);
+		}
+	}, [activeContributor, copy.supportRoleRefreshFailed]);
+
 	const handleTrackClick = useCallback((trackId) => {
 		if (!trackId) {
 			return;
@@ -1550,13 +1884,19 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 						"span",
 						{ className: "lyrics-credit-footer-value lyrics-credit-footer-contributors" },
 						...visibleContributors.flatMap((contributor, index) => {
+							const supportInfo = contributor.userHash ? supportByUserHash[contributor.userHash] : null;
+							const decorationStyle = getCreatorDecorationStyle(supportInfo?.tier, supportInfo?.decoration);
+							const decorationClass = decorationStyle
+								? ` is-supporter${supportInfo?.tier === "monthly" ? " is-monthly" : ""}${supportInfo?.decoration?.mode === "gradient" && supportInfo?.tier === "monthly" ? " is-gradient" : ""}`
+								: "";
 							const node = contributor.profileAvailable
 								? react.createElement(
 									"button",
 									{
 										type: "button",
 										key: contributor.key,
-										className: "lyrics-credit-footer-link",
+										className: `lyrics-credit-footer-link${decorationClass}`,
+										style: decorationStyle || undefined,
 										onPointerDown: (event) => event.stopPropagation(),
 										onMouseDown: (event) => event.stopPropagation(),
 										onClick: (event) => {
@@ -1571,7 +1911,8 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 									"span",
 									{
 										key: contributor.key,
-										className: "lyrics-credit-footer-name"
+										className: `lyrics-credit-footer-name${decorationClass}`,
+										style: decorationStyle || undefined
 									},
 									contributor.name
 								);
@@ -1614,7 +1955,12 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 			onLoadMore: handleLoadMore,
 			onTrackClick: handleTrackClick,
 			activeArtistFilter: profileArtistFilter,
-			onArtistFilterChange: handleArtistFilterChange
+			onArtistFilterChange: handleArtistFilterChange,
+			supportInfo: activeContributor?.userHash ? supportByUserHash[activeContributor.userHash] : null,
+			decorationPending,
+			onSaveDecoration: handleSaveDecoration,
+			onResetDecoration: handleResetDecoration,
+			onRefreshSupport: handleRefreshSupport
 		})
 		: null;
 

--- a/Utils.js
+++ b/Utils.js
@@ -2114,6 +2114,165 @@ const Utils = {
     return "https://lyrics.api.ivl.is/user";
   },
 
+  getCreatorDecorationDefaults() {
+    return {
+      mode: "solid",
+      solidColor: "#1ABC9C",
+      gradientStartColor: "#3498DB",
+      gradientEndColor: "#9B59B6",
+      gradientAngle: 90,
+    };
+  },
+
+  getCachedDiscordSupportTier(discordId, options = {}) {
+    if (!this.isDiscordUserHash(discordId)) return null;
+    try {
+      const raw = localStorage.getItem("ivLyrics:discord-support-tier-cache");
+      const cache = raw ? JSON.parse(raw) : {};
+      const entry = cache[String(discordId)];
+      if (
+        entry &&
+        ["none", "supporter", "monthly"].includes(entry.tier) &&
+        (options.allowExpired || Number(entry.expiresAt) > Date.now())
+      ) {
+        return entry;
+      }
+    } catch (error) {
+      console.warn("[ivLyrics] Failed to read Discord supporter cache:", error);
+    }
+    return null;
+  },
+
+  setCachedDiscordSupportTier(discordId, tier) {
+    if (!this.isDiscordUserHash(discordId) || !["none", "supporter", "monthly"].includes(tier)) {
+      return;
+    }
+    try {
+      const storageKey = "ivLyrics:discord-support-tier-cache";
+      const raw = localStorage.getItem(storageKey);
+      const cache = raw ? JSON.parse(raw) : {};
+      const now = Date.now();
+      for (const [key, entry] of Object.entries(cache)) {
+        if (!entry || Number(entry.expiresAt) < now - 24 * 60 * 60 * 1000) {
+          delete cache[key];
+        }
+      }
+      cache[String(discordId)] = {
+        tier,
+        expiresAt: now + 60 * 60 * 1000,
+      };
+      localStorage.setItem(storageKey, JSON.stringify(cache));
+    } catch (error) {
+      console.warn("[ivLyrics] Failed to update Discord supporter cache:", error);
+    }
+  },
+
+  async fetchDiscordSupportTier(discordId, options = {}) {
+    const normalizedId = String(discordId || "").trim();
+    if (!this.isDiscordUserHash(normalizedId)) return "none";
+
+    if (!options.forceRefresh) {
+      const cached = this.getCachedDiscordSupportTier(normalizedId);
+      if (cached) return cached.tier;
+    }
+
+    this._discordSupportTierRequests ||= new Map();
+    if (!options.forceRefresh && this._discordSupportTierRequests.has(normalizedId)) {
+      return await this._discordSupportTierRequests.get(normalizedId);
+    }
+
+    const request = (async () => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 4000);
+      try {
+        const response = await fetch(
+          `https://discord.ivl.is/v1/user/${encodeURIComponent(normalizedId)}`,
+          {
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+          }
+        );
+        if (!response.ok) throw new Error(`Discord member lookup failed (${response.status})`);
+        const body = await response.json();
+        const roleIds = new Set(
+          (Array.isArray(body?.data?.roles) ? body.data.roles : []).map((role) => String(role?.id || ""))
+        );
+        const tier = roleIds.has("1530978173590966282")
+          ? "monthly"
+          : roleIds.has("1530978124073013478")
+            ? "supporter"
+            : "none";
+        this.setCachedDiscordSupportTier(normalizedId, tier);
+        return tier;
+      } catch (error) {
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    })();
+
+    this._discordSupportTierRequests.set(normalizedId, request);
+    try {
+      return await request;
+    } finally {
+      if (this._discordSupportTierRequests.get(normalizedId) === request) {
+        this._discordSupportTierRequests.delete(normalizedId);
+      }
+    }
+  },
+
+  async fetchCreatorDecorations(userHashes) {
+    const normalized = [...new Set((Array.isArray(userHashes) ? userHashes : [])
+      .map((value) => String(value || "").trim())
+      .filter((value) => this.isDiscordUserHash(value)))].slice(0, 10);
+    if (!normalized.length) return {};
+
+    const params = new URLSearchParams({ userHashes: normalized.join(",") });
+    const response = await fetch(`${this.getAccountApiBase()}/creator-decorations?${params.toString()}`, {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const body = await response.json();
+    if (!response.ok || !body?.success) {
+      throw new Error(body?.error || "Failed to load creator decoration.");
+    }
+    return Object.fromEntries((body?.data?.items || []).map((item) => [item.userHash, item.decoration]));
+  },
+
+  async saveOwnCreatorDecoration(decoration) {
+    const response = await fetch(`${this.getAccountApiBase()}/creator-decoration`, {
+      method: "PUT",
+      cache: "no-store",
+      headers: this.getApiHeaders({
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify(decoration),
+    });
+    const body = await response.json();
+    if (!response.ok || !body?.success) {
+      const error = new Error(body?.error || "Failed to save creator decoration.");
+      error.status = response.status;
+      error.code = body?.code || "";
+      throw error;
+    }
+    return body.data;
+  },
+
+  async resetOwnCreatorDecoration() {
+    const response = await fetch(`${this.getAccountApiBase()}/creator-decoration`, {
+      method: "DELETE",
+      cache: "no-store",
+      headers: this.getApiHeaders({ Accept: "application/json" }),
+    });
+    const body = await response.json();
+    if (!response.ok || !body?.success) {
+      throw new Error(body?.error || "Failed to reset creator decoration.");
+    }
+    return body.data;
+  },
+
   async fetchAccountProfile(options = {}) {
     const includeUserHash = options.includeUserHash !== false;
     const currentUserHash = this.getUserHash();

--- a/langs/LangAr.js
+++ b/langs/LangAr.js
@@ -862,7 +862,27 @@ window.LANG_AR = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "داعم",
+    "monthlySupporter": "داعم شهري",
+    "nicknameStyle": "نمط الاسم المستعار",
+    "nicknameStyleDesc": "يُستخدم هذا اللون لاسمك في رصيد صانع المزامنة أسفل كلمات الأغنية.",
+    "solid": "موحّد",
+    "gradient": "تدرّج",
+    "solidColor": "لون موحّد",
+    "gradientStart": "لون البداية",
+    "gradientEnd": "لون النهاية",
+    "gradientAngle": "زاوية التدرّج",
+    "decorationPreview": "معاينة",
+    "saveDecoration": "حفظ اللون",
+    "resetDecoration": "إعادة الضبط إلى الافتراضي",
+    "refreshSupportRole": "تحديث دور الداعم",
+    "supportRoleNotFound": "لم يتم العثور على دور داعم. حدّث بعد تعيين دورك في Discord.",
+    "monthlyOnlyGradient": "التدرّجات متاحة للداعمين الشهريين فقط.",
+    "decorationSaved": "تم حفظ لون الاسم المستعار.",
+    "decorationReset": "تمت إعادة ضبط لون الاسم المستعار.",
+    "decorationSaveFailed": "تعذر حفظ لون الاسم المستعار.",
+    "supportRoleRefreshFailed": "تعذر تحديث دور الداعم."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangBn.js
+++ b/langs/LangBn.js
@@ -862,7 +862,27 @@ window.LANG_BN = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "সমর্থক",
+    "monthlySupporter": "মাসিক সমর্থক",
+    "nicknameStyle": "ডাকনামের ধরন",
+    "nicknameStyleDesc": "গানের কথার নিচে সিঙ্ক নির্মাতার ক্রেডিটে আপনার নামের জন্য এই রং ব্যবহার করা হবে।",
+    "solid": "একক রং",
+    "gradient": "গ্রেডিয়েন্ট",
+    "solidColor": "একক রং",
+    "gradientStart": "শুরুর রং",
+    "gradientEnd": "শেষের রং",
+    "gradientAngle": "গ্রেডিয়েন্টের কোণ",
+    "decorationPreview": "প্রিভিউ",
+    "saveDecoration": "রং সংরক্ষণ করুন",
+    "resetDecoration": "ডিফল্টে ফিরিয়ে নিন",
+    "refreshSupportRole": "সমর্থকের ভূমিকা রিফ্রেশ করুন",
+    "supportRoleNotFound": "সমর্থকের ভূমিকা পাওয়া যায়নি। Discord-এ ভূমিকা দেওয়ার পর রিফ্রেশ করুন।",
+    "monthlyOnlyGradient": "গ্রেডিয়েন্ট শুধু মাসিক সমর্থকদের জন্য উপলভ্য।",
+    "decorationSaved": "ডাকনামের রং সংরক্ষিত হয়েছে।",
+    "decorationReset": "ডাকনামের রং রিসেট করা হয়েছে।",
+    "decorationSaveFailed": "ডাকনামের রং সংরক্ষণ করা যায়নি।",
+    "supportRoleRefreshFailed": "সমর্থকের ভূমিকা রিফ্রেশ করা যায়নি।"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangCs.js
+++ b/langs/LangCs.js
@@ -862,7 +862,27 @@ window.LANG_CS = {
     "artistGroups": "Skupiny umělců",
     "noArtistStats": "Zatím žádné statistiky interpreta.",
     "clearArtistFilter": "Vymazat filtr interpreta",
-    "filteredArtist": "Filtrovaný umělec"
+    "filteredArtist": "Filtrovaný umělec",
+    "supporter": "Podporovatel",
+    "monthlySupporter": "Měsíční podporovatel",
+    "nicknameStyle": "Vzhled přezdívky",
+    "nicknameStyleDesc": "Tato barva se použije pro vaše jméno v údaji o autorovi synchronizace pod textem.",
+    "solid": "Jednobarevné",
+    "gradient": "Přechod",
+    "solidColor": "Jedna barva",
+    "gradientStart": "Počáteční barva",
+    "gradientEnd": "Koncová barva",
+    "gradientAngle": "Úhel přechodu",
+    "decorationPreview": "Náhled",
+    "saveDecoration": "Uložit barvu",
+    "resetDecoration": "Obnovit výchozí",
+    "refreshSupportRole": "Obnovit roli podporovatele",
+    "supportRoleNotFound": "Role podporovatele nebyla nalezena. Po přidělení role na Discordu ji obnovte.",
+    "monthlyOnlyGradient": "Přechody jsou dostupné pouze měsíčním podporovatelům.",
+    "decorationSaved": "Barva přezdívky byla uložena.",
+    "decorationReset": "Barva přezdívky byla obnovena.",
+    "decorationSaveFailed": "Barvu přezdívky se nepodařilo uložit.",
+    "supportRoleRefreshFailed": "Roli podporovatele se nepodařilo obnovit."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangDe.js
+++ b/langs/LangDe.js
@@ -862,7 +862,27 @@ window.LANG_DE = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Unterstützer",
+    "monthlySupporter": "Monatlicher Unterstützer",
+    "nicknameStyle": "Spitznamen-Stil",
+    "nicknameStyleDesc": "Diese Farbe wird für deinen Namen im Hinweis zum Sync-Ersteller unter den Lyrics verwendet.",
+    "solid": "Einfarbig",
+    "gradient": "Farbverlauf",
+    "solidColor": "Einfarbig",
+    "gradientStart": "Startfarbe",
+    "gradientEnd": "Endfarbe",
+    "gradientAngle": "Verlaufswinkel",
+    "decorationPreview": "Vorschau",
+    "saveDecoration": "Farbe speichern",
+    "resetDecoration": "Auf Standard zurücksetzen",
+    "refreshSupportRole": "Unterstützerrolle aktualisieren",
+    "supportRoleNotFound": "Keine Unterstützerrolle gefunden. Aktualisiere sie, nachdem dir die Discord-Rolle zugewiesen wurde.",
+    "monthlyOnlyGradient": "Farbverläufe sind nur für monatliche Unterstützer verfügbar.",
+    "decorationSaved": "Spitznamenfarbe gespeichert.",
+    "decorationReset": "Spitznamenfarbe zurückgesetzt.",
+    "decorationSaveFailed": "Spitznamenfarbe konnte nicht gespeichert werden.",
+    "supportRoleRefreshFailed": "Unterstützerrolle konnte nicht aktualisiert werden."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangEn.js
+++ b/langs/LangEn.js
@@ -862,7 +862,27 @@ window.LANG_EN = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Supporter",
+    "monthlySupporter": "Monthly Supporter",
+    "nicknameStyle": "Nickname style",
+    "nicknameStyleDesc": "This color is used for your name in the sync creator credit below the lyrics.",
+    "solid": "Solid",
+    "gradient": "Gradient",
+    "solidColor": "Solid color",
+    "gradientStart": "Start color",
+    "gradientEnd": "End color",
+    "gradientAngle": "Gradient angle",
+    "decorationPreview": "Preview",
+    "saveDecoration": "Save color",
+    "resetDecoration": "Reset to default",
+    "refreshSupportRole": "Refresh supporter role",
+    "supportRoleNotFound": "No supporter role was found. Refresh after your Discord role is assigned.",
+    "monthlyOnlyGradient": "Gradients are available to Monthly Supporters only.",
+    "decorationSaved": "Nickname color saved.",
+    "decorationReset": "Nickname color reset.",
+    "decorationSaveFailed": "Failed to save nickname color.",
+    "supportRoleRefreshFailed": "Failed to refresh supporter role."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangEs.js
+++ b/langs/LangEs.js
@@ -862,7 +862,27 @@ window.LANG_ES = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Colaborador",
+    "monthlySupporter": "Colaborador mensual",
+    "nicknameStyle": "Estilo del apodo",
+    "nicknameStyleDesc": "Este color se usa para tu nombre en el crédito del creador de sincronización bajo la letra.",
+    "solid": "Sólido",
+    "gradient": "Degradado",
+    "solidColor": "Color sólido",
+    "gradientStart": "Color inicial",
+    "gradientEnd": "Color final",
+    "gradientAngle": "Ángulo del degradado",
+    "decorationPreview": "Vista previa",
+    "saveDecoration": "Guardar color",
+    "resetDecoration": "Restablecer valores",
+    "refreshSupportRole": "Actualizar rol de colaborador",
+    "supportRoleNotFound": "No se encontró ningún rol de colaborador. Actualízalo después de recibir el rol en Discord.",
+    "monthlyOnlyGradient": "Los degradados solo están disponibles para colaboradores mensuales.",
+    "decorationSaved": "Color del apodo guardado.",
+    "decorationReset": "Color del apodo restablecido.",
+    "decorationSaveFailed": "No se pudo guardar el color del apodo.",
+    "supportRoleRefreshFailed": "No se pudo actualizar el rol de colaborador."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangFa.js
+++ b/langs/LangFa.js
@@ -862,7 +862,27 @@ window.LANG_FA = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "حامی",
+    "monthlySupporter": "حامی ماهانه",
+    "nicknameStyle": "سبک نام مستعار",
+    "nicknameStyleDesc": "این رنگ برای نام شما در بخش سازنده همگام‌سازی زیر متن ترانه استفاده می‌شود.",
+    "solid": "یکدست",
+    "gradient": "گرادیان",
+    "solidColor": "رنگ یکدست",
+    "gradientStart": "رنگ آغاز",
+    "gradientEnd": "رنگ پایان",
+    "gradientAngle": "زاویه گرادیان",
+    "decorationPreview": "پیش‌نمایش",
+    "saveDecoration": "ذخیره رنگ",
+    "resetDecoration": "بازنشانی به پیش‌فرض",
+    "refreshSupportRole": "تازه‌سازی نقش حامی",
+    "supportRoleNotFound": "نقش حامی پیدا نشد. پس از اختصاص نقش در Discord آن را تازه‌سازی کنید.",
+    "monthlyOnlyGradient": "گرادیان فقط برای حامیان ماهانه در دسترس است.",
+    "decorationSaved": "رنگ نام مستعار ذخیره شد.",
+    "decorationReset": "رنگ نام مستعار بازنشانی شد.",
+    "decorationSaveFailed": "ذخیره رنگ نام مستعار انجام نشد.",
+    "supportRoleRefreshFailed": "تازه‌سازی نقش حامی انجام نشد."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangFr.js
+++ b/langs/LangFr.js
@@ -862,7 +862,27 @@ window.LANG_FR = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Soutien",
+    "monthlySupporter": "Soutien mensuel",
+    "nicknameStyle": "Style du pseudo",
+    "nicknameStyleDesc": "Cette couleur est utilisée pour ton nom dans le crédit du créateur de sync sous les paroles.",
+    "solid": "Uni",
+    "gradient": "Dégradé",
+    "solidColor": "Couleur unie",
+    "gradientStart": "Couleur de début",
+    "gradientEnd": "Couleur de fin",
+    "gradientAngle": "Angle du dégradé",
+    "decorationPreview": "Aperçu",
+    "saveDecoration": "Enregistrer la couleur",
+    "resetDecoration": "Rétablir par défaut",
+    "refreshSupportRole": "Actualiser le rôle de soutien",
+    "supportRoleNotFound": "Aucun rôle de soutien trouvé. Actualise-le après l’attribution de ton rôle Discord.",
+    "monthlyOnlyGradient": "Les dégradés sont réservés aux soutiens mensuels.",
+    "decorationSaved": "Couleur du pseudo enregistrée.",
+    "decorationReset": "Couleur du pseudo réinitialisée.",
+    "decorationSaveFailed": "Impossible d’enregistrer la couleur du pseudo.",
+    "supportRoleRefreshFailed": "Impossible d’actualiser le rôle de soutien."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangHi.js
+++ b/langs/LangHi.js
@@ -862,7 +862,27 @@ window.LANG_HI = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "समर्थक",
+    "monthlySupporter": "मासिक समर्थक",
+    "nicknameStyle": "उपनाम की शैली",
+    "nicknameStyleDesc": "यह रंग गीत के बोल के नीचे सिंक निर्माता श्रेय में आपके नाम पर दिखेगा।",
+    "solid": "एक रंग",
+    "gradient": "ग्रेडिएंट",
+    "solidColor": "एकल रंग",
+    "gradientStart": "शुरुआती रंग",
+    "gradientEnd": "अंतिम रंग",
+    "gradientAngle": "ग्रेडिएंट का कोण",
+    "decorationPreview": "पूर्वावलोकन",
+    "saveDecoration": "रंग सहेजें",
+    "resetDecoration": "डिफ़ॉल्ट पर रीसेट करें",
+    "refreshSupportRole": "समर्थक भूमिका रीफ़्रेश करें",
+    "supportRoleNotFound": "समर्थक भूमिका नहीं मिली। Discord भूमिका मिलने के बाद रीफ़्रेश करें।",
+    "monthlyOnlyGradient": "ग्रेडिएंट केवल मासिक समर्थकों के लिए उपलब्ध हैं।",
+    "decorationSaved": "उपनाम का रंग सहेजा गया।",
+    "decorationReset": "उपनाम का रंग रीसेट किया गया।",
+    "decorationSaveFailed": "उपनाम का रंग सहेजा नहीं जा सका।",
+    "supportRoleRefreshFailed": "समर्थक भूमिका रीफ़्रेश नहीं की जा सकी।"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangId.js
+++ b/langs/LangId.js
@@ -862,7 +862,27 @@ window.LANG_ID = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Pendukung",
+    "monthlySupporter": "Pendukung bulanan",
+    "nicknameStyle": "Gaya nama panggilan",
+    "nicknameStyleDesc": "Warna ini digunakan untuk namamu pada kredit kreator sinkronisasi di bawah lirik.",
+    "solid": "Polos",
+    "gradient": "Gradasi",
+    "solidColor": "Warna polos",
+    "gradientStart": "Warna awal",
+    "gradientEnd": "Warna akhir",
+    "gradientAngle": "Sudut gradasi",
+    "decorationPreview": "Pratinjau",
+    "saveDecoration": "Simpan warna",
+    "resetDecoration": "Atur ulang ke bawaan",
+    "refreshSupportRole": "Segarkan peran pendukung",
+    "supportRoleNotFound": "Peran pendukung tidak ditemukan. Segarkan setelah peran Discord diberikan.",
+    "monthlyOnlyGradient": "Gradasi hanya tersedia untuk pendukung bulanan.",
+    "decorationSaved": "Warna nama panggilan disimpan.",
+    "decorationReset": "Warna nama panggilan diatur ulang.",
+    "decorationSaveFailed": "Warna nama panggilan gagal disimpan.",
+    "supportRoleRefreshFailed": "Peran pendukung gagal disegarkan."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangIt.js
+++ b/langs/LangIt.js
@@ -862,7 +862,27 @@ window.LANG_IT = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Sostenitore",
+    "monthlySupporter": "Sostenitore mensile",
+    "nicknameStyle": "Stile del nickname",
+    "nicknameStyleDesc": "Questo colore viene usato per il tuo nome nel credito del creatore della sincronizzazione sotto il testo.",
+    "solid": "Tinta unita",
+    "gradient": "Gradiente",
+    "solidColor": "Colore uniforme",
+    "gradientStart": "Colore iniziale",
+    "gradientEnd": "Colore finale",
+    "gradientAngle": "Angolo del gradiente",
+    "decorationPreview": "Anteprima",
+    "saveDecoration": "Salva colore",
+    "resetDecoration": "Ripristina predefinito",
+    "refreshSupportRole": "Aggiorna ruolo sostenitore",
+    "supportRoleNotFound": "Nessun ruolo sostenitore trovato. Aggiorna dopo l’assegnazione del ruolo su Discord.",
+    "monthlyOnlyGradient": "I gradienti sono disponibili solo per i sostenitori mensili.",
+    "decorationSaved": "Colore del nickname salvato.",
+    "decorationReset": "Colore del nickname reimpostato.",
+    "decorationSaveFailed": "Impossibile salvare il colore del nickname.",
+    "supportRoleRefreshFailed": "Impossibile aggiornare il ruolo sostenitore."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangJa.js
+++ b/langs/LangJa.js
@@ -862,7 +862,27 @@ window.LANG_JA = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "サポーター",
+    "monthlySupporter": "月額サポーター",
+    "nicknameStyle": "ニックネームのスタイル",
+    "nicknameStyleDesc": "この色は歌詞下部の同期制作者クレジットに表示される名前に使用されます。",
+    "solid": "単色",
+    "gradient": "グラデーション",
+    "solidColor": "単色",
+    "gradientStart": "開始色",
+    "gradientEnd": "終了色",
+    "gradientAngle": "グラデーションの角度",
+    "decorationPreview": "プレビュー",
+    "saveDecoration": "色を保存",
+    "resetDecoration": "デフォルトに戻す",
+    "refreshSupportRole": "サポーターロールを更新",
+    "supportRoleNotFound": "サポーターロールが見つかりません。Discordでロールが付与された後に更新してください。",
+    "monthlyOnlyGradient": "グラデーションは月額サポーター限定です。",
+    "decorationSaved": "ニックネームの色を保存しました。",
+    "decorationReset": "ニックネームの色をリセットしました。",
+    "decorationSaveFailed": "ニックネームの色を保存できませんでした。",
+    "supportRoleRefreshFailed": "サポーターロールを更新できませんでした。"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangKo.js
+++ b/langs/LangKo.js
@@ -862,7 +862,27 @@ window.LANG_KO = {
     "artistGroups": "아티스트 수",
     "noArtistStats": "아직 아티스트 통계가 없습니다.",
     "clearArtistFilter": "아티스트 필터 해제",
-    "filteredArtist": "필터 중인 아티스트"
+    "filteredArtist": "필터 중인 아티스트",
+    "supporter": "후원자",
+    "monthlySupporter": "월간 후원자",
+    "nicknameStyle": "닉네임 스타일",
+    "nicknameStyleDesc": "가사 하단 싱크 제작자 영역에 표시될 닉네임 색상입니다.",
+    "solid": "단색",
+    "gradient": "그라데이션",
+    "solidColor": "단색 색상",
+    "gradientStart": "시작 색상",
+    "gradientEnd": "끝 색상",
+    "gradientAngle": "그라데이션 각도",
+    "decorationPreview": "미리보기",
+    "saveDecoration": "색상 저장",
+    "resetDecoration": "기본값으로 초기화",
+    "refreshSupportRole": "후원 역할 새로고침",
+    "supportRoleNotFound": "후원 역할을 찾지 못했습니다. 디스코드 역할이 지급된 뒤 새로고침하세요.",
+    "monthlyOnlyGradient": "그라데이션은 월간 후원자 전용 기능입니다.",
+    "decorationSaved": "닉네임 색상을 저장했습니다.",
+    "decorationReset": "닉네임 색상을 초기화했습니다.",
+    "decorationSaveFailed": "닉네임 색상을 저장하지 못했습니다.",
+    "supportRoleRefreshFailed": "후원 역할을 새로고침하지 못했습니다."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangMs.js
+++ b/langs/LangMs.js
@@ -862,7 +862,27 @@ window.LANG_MS = {
     "artistGroups": "Bilangan Artis",
     "noArtistStats": "Belum ada statistik artis.",
     "clearArtistFilter": "Kosongkan Penapis Artis",
-    "filteredArtist": "Artis sedang ditapis"
+    "filteredArtist": "Artis sedang ditapis",
+    "supporter": "Penyokong",
+    "monthlySupporter": "Penyokong bulanan",
+    "nicknameStyle": "Gaya nama samaran",
+    "nicknameStyleDesc": "Warna ini digunakan untuk nama anda dalam kredit pencipta segerak di bawah lirik.",
+    "solid": "Pejal",
+    "gradient": "Gradien",
+    "solidColor": "Warna pejal",
+    "gradientStart": "Warna mula",
+    "gradientEnd": "Warna akhir",
+    "gradientAngle": "Sudut gradien",
+    "decorationPreview": "Pratonton",
+    "saveDecoration": "Simpan warna",
+    "resetDecoration": "Tetapkan semula kepada lalai",
+    "refreshSupportRole": "Segarkan peranan penyokong",
+    "supportRoleNotFound": "Peranan penyokong tidak ditemui. Segarkan selepas peranan Discord anda diberikan.",
+    "monthlyOnlyGradient": "Gradien hanya tersedia untuk penyokong bulanan.",
+    "decorationSaved": "Warna nama samaran disimpan.",
+    "decorationReset": "Warna nama samaran ditetapkan semula.",
+    "decorationSaveFailed": "Warna nama samaran gagal disimpan.",
+    "supportRoleRefreshFailed": "Peranan penyokong gagal disegarkan."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangPt.js
+++ b/langs/LangPt.js
@@ -862,7 +862,27 @@ window.LANG_PT = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Apoiador",
+    "monthlySupporter": "Apoiador mensal",
+    "nicknameStyle": "Estilo do apelido",
+    "nicknameStyleDesc": "Esta cor é usada no seu nome no crédito do criador da sincronização abaixo da letra.",
+    "solid": "Sólido",
+    "gradient": "Gradiente",
+    "solidColor": "Cor sólida",
+    "gradientStart": "Cor inicial",
+    "gradientEnd": "Cor final",
+    "gradientAngle": "Ângulo do gradiente",
+    "decorationPreview": "Prévia",
+    "saveDecoration": "Salvar cor",
+    "resetDecoration": "Restaurar padrão",
+    "refreshSupportRole": "Atualizar cargo de apoiador",
+    "supportRoleNotFound": "Nenhum cargo de apoiador foi encontrado. Atualize depois que o cargo for atribuído no Discord.",
+    "monthlyOnlyGradient": "Gradientes estão disponíveis apenas para apoiadores mensais.",
+    "decorationSaved": "Cor do apelido salva.",
+    "decorationReset": "Cor do apelido restaurada.",
+    "decorationSaveFailed": "Não foi possível salvar a cor do apelido.",
+    "supportRoleRefreshFailed": "Não foi possível atualizar o cargo de apoiador."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangRu.js
+++ b/langs/LangRu.js
@@ -862,7 +862,27 @@ window.LANG_RU = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Спонсор",
+    "monthlySupporter": "Ежемесячный спонсор",
+    "nicknameStyle": "Стиль имени",
+    "nicknameStyleDesc": "Этот цвет используется для вашего имени в подписи автора синхронизации под текстом песни.",
+    "solid": "Однотонный",
+    "gradient": "Градиент",
+    "solidColor": "Однотонный цвет",
+    "gradientStart": "Начальный цвет",
+    "gradientEnd": "Конечный цвет",
+    "gradientAngle": "Угол градиента",
+    "decorationPreview": "Предпросмотр",
+    "saveDecoration": "Сохранить цвет",
+    "resetDecoration": "Сбросить настройки",
+    "refreshSupportRole": "Обновить роль спонсора",
+    "supportRoleNotFound": "Роль спонсора не найдена. Обновите после назначения роли в Discord.",
+    "monthlyOnlyGradient": "Градиенты доступны только ежемесячным спонсорам.",
+    "decorationSaved": "Цвет имени сохранён.",
+    "decorationReset": "Цвет имени сброшен.",
+    "decorationSaveFailed": "Не удалось сохранить цвет имени.",
+    "supportRoleRefreshFailed": "Не удалось обновить роль спонсора."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangSv.js
+++ b/langs/LangSv.js
@@ -862,7 +862,27 @@ window.LANG_SV = {
     "artistGroups": "Konstnärsgrupper",
     "noArtistStats": "Ingen artiststatistik ännu.",
     "clearArtistFilter": "Rensa artistfilter",
-    "filteredArtist": "Filtrerad artist"
+    "filteredArtist": "Filtrerad artist",
+    "supporter": "Supporter",
+    "monthlySupporter": "Månadssupporter",
+    "nicknameStyle": "Stil för smeknamn",
+    "nicknameStyleDesc": "Den här färgen används för ditt namn i krediteringen av synkskaparen under låttexten.",
+    "solid": "Enfärgad",
+    "gradient": "Toning",
+    "solidColor": "Enfärgad färg",
+    "gradientStart": "Startfärg",
+    "gradientEnd": "Slutfärg",
+    "gradientAngle": "Toningsvinkel",
+    "decorationPreview": "Förhandsvisning",
+    "saveDecoration": "Spara färg",
+    "resetDecoration": "Återställ standard",
+    "refreshSupportRole": "Uppdatera supporterroll",
+    "supportRoleNotFound": "Ingen supporterroll hittades. Uppdatera efter att din Discord-roll har tilldelats.",
+    "monthlyOnlyGradient": "Toningar är endast tillgängliga för månadssupportrar.",
+    "decorationSaved": "Smeknamnsfärgen har sparats.",
+    "decorationReset": "Smeknamnsfärgen har återställts.",
+    "decorationSaveFailed": "Det gick inte att spara smeknamnsfärgen.",
+    "supportRoleRefreshFailed": "Det gick inte att uppdatera supporterrollen."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangTh.js
+++ b/langs/LangTh.js
@@ -862,7 +862,27 @@ window.LANG_TH = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "ผู้สนับสนุน",
+    "monthlySupporter": "ผู้สนับสนุนรายเดือน",
+    "nicknameStyle": "รูปแบบชื่อเล่น",
+    "nicknameStyleDesc": "สีนี้ใช้กับชื่อของคุณในเครดิตผู้สร้างซิงก์ใต้เนื้อเพลง",
+    "solid": "สีเดียว",
+    "gradient": "ไล่เฉดสี",
+    "solidColor": "สีเดียว",
+    "gradientStart": "สีเริ่มต้น",
+    "gradientEnd": "สีสิ้นสุด",
+    "gradientAngle": "มุมไล่เฉดสี",
+    "decorationPreview": "ตัวอย่าง",
+    "saveDecoration": "บันทึกสี",
+    "resetDecoration": "คืนค่าเริ่มต้น",
+    "refreshSupportRole": "รีเฟรชบทบาทผู้สนับสนุน",
+    "supportRoleNotFound": "ไม่พบบทบาทผู้สนับสนุน โปรดรีเฟรชหลังจากได้รับบทบาทใน Discord",
+    "monthlyOnlyGradient": "การไล่เฉดสีมีให้เฉพาะผู้สนับสนุนรายเดือนเท่านั้น",
+    "decorationSaved": "บันทึกสีชื่อเล่นแล้ว",
+    "decorationReset": "รีเซ็ตสีชื่อเล่นแล้ว",
+    "decorationSaveFailed": "บันทึกสีชื่อเล่นไม่สำเร็จ",
+    "supportRoleRefreshFailed": "รีเฟรชบทบาทผู้สนับสนุนไม่สำเร็จ"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangTr.js
+++ b/langs/LangTr.js
@@ -862,7 +862,27 @@ window.LANG_TR = {
     "artistGroups": "Sanatçı Grupları",
     "noArtistStats": "Henüz sanatçı istatistiği yok.",
     "clearArtistFilter": "Sanatçı filtresini temizle",
-    "filteredArtist": "Filtrelenen sanatçı"
+    "filteredArtist": "Filtrelenen sanatçı",
+    "supporter": "Destekçi",
+    "monthlySupporter": "Aylık destekçi",
+    "nicknameStyle": "Takma ad stili",
+    "nicknameStyleDesc": "Bu renk, şarkı sözlerinin altındaki senkron oluşturucu bilgisinde adınız için kullanılır.",
+    "solid": "Düz",
+    "gradient": "Geçiş",
+    "solidColor": "Düz renk",
+    "gradientStart": "Başlangıç rengi",
+    "gradientEnd": "Bitiş rengi",
+    "gradientAngle": "Geçiş açısı",
+    "decorationPreview": "Önizleme",
+    "saveDecoration": "Rengi kaydet",
+    "resetDecoration": "Varsayılana sıfırla",
+    "refreshSupportRole": "Destekçi rolünü yenile",
+    "supportRoleNotFound": "Destekçi rolü bulunamadı. Discord rolünüz atandıktan sonra yenileyin.",
+    "monthlyOnlyGradient": "Geçişler yalnızca aylık destekçilere açıktır.",
+    "decorationSaved": "Takma ad rengi kaydedildi.",
+    "decorationReset": "Takma ad rengi sıfırlandı.",
+    "decorationSaveFailed": "Takma ad rengi kaydedilemedi.",
+    "supportRoleRefreshFailed": "Destekçi rolü yenilenemedi."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangVi.js
+++ b/langs/LangVi.js
@@ -862,7 +862,27 @@ window.LANG_VI = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "Người ủng hộ",
+    "monthlySupporter": "Người ủng hộ hằng tháng",
+    "nicknameStyle": "Kiểu biệt danh",
+    "nicknameStyleDesc": "Màu này được dùng cho tên của bạn trong phần ghi công người tạo bản đồng bộ bên dưới lời bài hát.",
+    "solid": "Màu đơn",
+    "gradient": "Chuyển sắc",
+    "solidColor": "Màu đơn",
+    "gradientStart": "Màu bắt đầu",
+    "gradientEnd": "Màu kết thúc",
+    "gradientAngle": "Góc chuyển sắc",
+    "decorationPreview": "Xem trước",
+    "saveDecoration": "Lưu màu",
+    "resetDecoration": "Đặt lại mặc định",
+    "refreshSupportRole": "Làm mới vai trò người ủng hộ",
+    "supportRoleNotFound": "Không tìm thấy vai trò người ủng hộ. Hãy làm mới sau khi bạn được cấp vai trò trên Discord.",
+    "monthlyOnlyGradient": "Chuyển sắc chỉ dành cho người ủng hộ hằng tháng.",
+    "decorationSaved": "Đã lưu màu biệt danh.",
+    "decorationReset": "Đã đặt lại màu biệt danh.",
+    "decorationSaveFailed": "Không thể lưu màu biệt danh.",
+    "supportRoleRefreshFailed": "Không thể làm mới vai trò người ủng hộ."
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangZhCN.js
+++ b/langs/LangZhCN.js
@@ -862,7 +862,27 @@ window.LANG_ZH_CN = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "支持者",
+    "monthlySupporter": "月度支持者",
+    "nicknameStyle": "昵称样式",
+    "nicknameStyleDesc": "此颜色将用于歌词下方同步创作者署名中的昵称。",
+    "solid": "纯色",
+    "gradient": "渐变",
+    "solidColor": "纯色",
+    "gradientStart": "起始颜色",
+    "gradientEnd": "结束颜色",
+    "gradientAngle": "渐变角度",
+    "decorationPreview": "预览",
+    "saveDecoration": "保存颜色",
+    "resetDecoration": "恢复默认",
+    "refreshSupportRole": "刷新支持者身份组",
+    "supportRoleNotFound": "未找到支持者身份组。请在 Discord 身份组分配后刷新。",
+    "monthlyOnlyGradient": "渐变仅向月度支持者开放。",
+    "decorationSaved": "昵称颜色已保存。",
+    "decorationReset": "昵称颜色已重置。",
+    "decorationSaveFailed": "无法保存昵称颜色。",
+    "supportRoleRefreshFailed": "无法刷新支持者身份组。"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/langs/LangZhTW.js
+++ b/langs/LangZhTW.js
@@ -862,7 +862,27 @@ window.LANG_ZH_TW = {
     "artistGroups": "Artist Groups",
     "noArtistStats": "No artist stats yet.",
     "clearArtistFilter": "Clear artist filter",
-    "filteredArtist": "Filtered artist"
+    "filteredArtist": "Filtered artist",
+    "supporter": "支持者",
+    "monthlySupporter": "每月支持者",
+    "nicknameStyle": "暱稱樣式",
+    "nicknameStyleDesc": "此顏色將用於歌詞下方同步創作者署名中的暱稱。",
+    "solid": "純色",
+    "gradient": "漸層",
+    "solidColor": "純色",
+    "gradientStart": "起始顏色",
+    "gradientEnd": "結束顏色",
+    "gradientAngle": "漸層角度",
+    "decorationPreview": "預覽",
+    "saveDecoration": "儲存顏色",
+    "resetDecoration": "恢復預設",
+    "refreshSupportRole": "重新整理支持者身分組",
+    "supportRoleNotFound": "找不到支持者身分組。請在 Discord 身分組指派後重新整理。",
+    "monthlyOnlyGradient": "漸層僅供每月支持者使用。",
+    "decorationSaved": "暱稱顏色已儲存。",
+    "decorationReset": "暱稱顏色已重設。",
+    "decorationSaveFailed": "無法儲存暱稱顏色。",
+    "supportRoleRefreshFailed": "無法重新整理支持者身分組。"
   },
   "settingsAdvanced": {
     "patchNotes": {

--- a/style.css
+++ b/style.css
@@ -14811,6 +14811,19 @@ html.is-lp-view-exit::view-transition-new(root) {
   opacity: 1;
 }
 
+.lyrics-credit-footer-link.is-supporter,
+.lyrics-credit-footer-name.is-supporter {
+  font-weight: 700;
+  opacity: 1;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.34);
+}
+
+.lyrics-credit-footer-link.is-gradient,
+.lyrics-credit-footer-name.is-gradient {
+  display: inline-block;
+  background-size: 100% 100%;
+}
+
 .lyrics-creator-profile-overlay {
   position: fixed;
   inset: 0;
@@ -15770,6 +15783,264 @@ html.is-lp-view-exit::view-transition-new(root) {
   overflow-wrap: anywhere;
 }
 
+.lyrics-creator-profile-name-with-badge {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.lyrics-creator-support-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.lyrics-creator-support-badge.is-supporter {
+  color: #d9fff3;
+  background: rgba(26, 188, 156, 0.18);
+  border: 1px solid rgba(26, 188, 156, 0.38);
+}
+
+.lyrics-creator-support-badge.is-monthly {
+  color: #eaf4ff;
+  background: linear-gradient(135deg, rgba(52, 152, 219, 0.3), rgba(155, 89, 182, 0.3));
+  border: 1px solid rgba(104, 176, 232, 0.44);
+}
+
+.lyrics-creator-profile-modal[data-ui-theme="light"] .lyrics-creator-support-badge.is-supporter {
+  color: #08745f;
+  background: rgba(26, 188, 156, 0.11);
+  border-color: rgba(16, 139, 114, 0.26);
+}
+
+.lyrics-creator-profile-modal[data-ui-theme="light"] .lyrics-creator-support-badge.is-monthly {
+  color: #285c9c;
+  background: linear-gradient(135deg, rgba(52, 152, 219, 0.12), rgba(155, 89, 182, 0.12));
+  border-color: rgba(73, 112, 184, 0.24);
+}
+
+.lyrics-creator-decoration-editor {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 16px;
+  padding: 16px;
+  color: var(--creator-ink);
+  background: var(--creator-surface-2);
+  border: 1px solid var(--creator-line);
+  border-radius: 18px;
+}
+
+.lyrics-creator-decoration-heading,
+.lyrics-creator-decoration-actions,
+.lyrics-creator-decoration-color-control {
+  display: flex;
+  align-items: center;
+}
+
+.lyrics-creator-decoration-heading {
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.lyrics-creator-decoration-heading h3,
+.lyrics-creator-decoration-heading p {
+  margin: 0;
+}
+
+.lyrics-creator-decoration-heading h3 {
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.lyrics-creator-decoration-heading p {
+  margin-top: 4px;
+  color: var(--creator-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.lyrics-creator-decoration-modes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  padding: 4px;
+  background: var(--creator-surface);
+  border: 1px solid var(--creator-line);
+  border-radius: 13px;
+}
+
+.lyrics-creator-decoration-modes button,
+.lyrics-creator-decoration-actions button,
+.lyrics-creator-decoration-refresh-role {
+  min-height: 44px;
+  padding: 0 13px;
+  color: var(--creator-ink-2);
+  background: transparent;
+  border: 0;
+  border-radius: 10px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.lyrics-creator-decoration-modes button.is-active {
+  color: var(--creator-solid-text);
+  background: var(--creator-solid);
+}
+
+.lyrics-creator-decoration-modes button.is-locked:not(.is-active) {
+  color: var(--creator-muted);
+  border: 1px dashed var(--creator-line-2);
+}
+
+.lyrics-creator-decoration-modes button:disabled,
+.lyrics-creator-decoration-actions button:disabled,
+.lyrics-creator-decoration-refresh-role:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.lyrics-creator-decoration-notice {
+  padding: 10px 12px;
+  color: #f5c96a;
+  background: rgba(245, 185, 66, 0.1);
+  border: 1px solid rgba(245, 185, 66, 0.22);
+  border-radius: 12px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.lyrics-creator-decoration-notice[hidden] {
+  display: none;
+}
+
+.lyrics-creator-decoration-modes button:focus-visible,
+.lyrics-creator-decoration-actions button:focus-visible,
+.lyrics-creator-decoration-refresh-role:focus-visible,
+.lyrics-creator-decoration-field input:focus-visible {
+  outline: 2px solid var(--creator-solid);
+  outline-offset: 2px;
+}
+
+.lyrics-creator-profile-modal[data-ui-theme="light"] .lyrics-creator-decoration-notice {
+  color: #8b5e05;
+  background: rgba(245, 185, 66, 0.1);
+  border-color: rgba(139, 94, 5, 0.17);
+}
+
+.lyrics-creator-decoration-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.lyrics-creator-decoration-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  min-width: 0;
+  color: var(--creator-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.lyrics-creator-decoration-color-control {
+  gap: 8px;
+  min-height: 40px;
+  padding: 5px 9px;
+  color: var(--creator-ink-2);
+  background: var(--creator-surface);
+  border: 1px solid var(--creator-line);
+  border-radius: 12px;
+}
+
+.lyrics-creator-decoration-color-control input[type="color"] {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.lyrics-creator-decoration-color-control code {
+  color: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+.lyrics-creator-decoration-field input[type="range"] {
+  width: 100%;
+  accent-color: var(--creator-solid);
+}
+
+.lyrics-creator-decoration-preview {
+  min-height: 62px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px solid var(--creator-line);
+  border-radius: 14px;
+}
+
+.lyrics-creator-profile-modal[data-ui-theme="light"] .lyrics-creator-decoration-preview {
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.lyrics-creator-decoration-preview-label {
+  color: var(--creator-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+
+.lyrics-creator-decoration-preview strong {
+  width: fit-content;
+  font-size: 15px;
+  line-height: 1.3;
+}
+
+.lyrics-creator-decoration-actions {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.lyrics-creator-decoration-actions button {
+  background: var(--creator-surface);
+  border: 1px solid var(--creator-line);
+}
+
+.lyrics-creator-decoration-refresh-role {
+  flex: 0 0 auto;
+  color: var(--creator-solid-text);
+  background: var(--creator-solid);
+  border: 1px solid var(--creator-solid);
+}
+
+.lyrics-creator-decoration-actions button.is-primary {
+  color: var(--creator-solid-text);
+  background: var(--creator-solid);
+  border-color: var(--creator-solid);
+}
+
 .lyrics-creator-profile-handle,
 .lyrics-creator-profile-modal[data-ui-theme="light"] .lyrics-creator-profile-handle {
   margin-top: 4px;
@@ -16298,6 +16569,24 @@ html.is-lp-view-exit::view-transition-new(root) {
     grid-column: 2;
     align-items: flex-start;
     text-align: left;
+  }
+
+  .lyrics-creator-decoration-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lyrics-creator-decoration-heading {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 470px) {
+  .lyrics-creator-decoration-heading {
+    flex-direction: column;
+  }
+
+  .lyrics-creator-decoration-refresh-role {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
Adds supporter badges and custom sync-creator credit colors. Monthly supporters can use gradients, one-time supporters use solid colors, and all 22 desktop locales include the new UI copy.\n\nVerification:\n- JavaScript syntax checks\n- 22-locale supporter key audit\n- git diff --check