### PR TITLE
Fix creator decoration input crashes

### DIFF
--- a/.github/scripts/creator-decoration-inputs.test.cjs
+++ b/.github/scripts/creator-decoration-inputs.test.cjs
@@ -1,0 +1,28 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const test = require('node:test');
+
+const pagesSource = readFileSync(resolve(__dirname, '..', '..', 'Pages.js'), 'utf8');
+
+function getDecorationEditorSource() {
+  const start = pagesSource.indexOf('const CreatorDecorationEditor');
+  const end = pagesSource.indexOf('const SyncCreatorProfileModal', start);
+  assert.notEqual(start, -1, 'creator decoration editor must exist');
+  assert.notEqual(end, -1, 'creator decoration editor boundary must exist');
+  return pagesSource.slice(start, end);
+}
+
+test('creator decoration inputs snapshot DOM values before functional state updates', () => {
+  const source = getDecorationEditorSource();
+
+  assert.match(source, /const nextColor = event\.currentTarget\.value\.toUpperCase\(\);/);
+  assert.match(source, /\[key\]: nextColor/);
+  assert.match(source, /const nextAngle = Number\(event\.currentTarget\.value\);/);
+  assert.match(source, /gradientAngle: nextAngle/);
+  assert.doesNotMatch(
+    source,
+    /setDraft\(\(current\) => \([^)]*event\.currentTarget/s,
+    'React event objects must not be read from deferred state updater callbacks'
+  );
+});

--- a/.github/workflows/pc-release.yml
+++ b/.github/workflows/pc-release.yml
@@ -72,6 +72,7 @@ jobs:
           node --test .github/scripts/karaoke-italic-clipping.test.cjs
           node --test .github/scripts/performance-frame-rate.test.cjs
           node --test .github/scripts/creator-profile-sort-removal.test.cjs
+          node --test .github/scripts/creator-decoration-inputs.test.cjs
           node --test .github/scripts/send_release_webhook.test.mjs
           python3 -m json.tool manifest.json >/dev/null
           git diff --check

--- a/Pages.js
+++ b/Pages.js
@@ -666,7 +666,10 @@ const CreatorDecorationEditor = react.memo(({
 				type: "color",
 				value: draft[key],
 				disabled: pending,
-				onChange: (event) => setDraft((current) => ({ ...current, [key]: event.currentTarget.value.toUpperCase() }))
+				onChange: (event) => {
+					const nextColor = event.currentTarget.value.toUpperCase();
+					setDraft((current) => ({ ...current, [key]: nextColor }));
+				}
 			}),
 			react.createElement("code", null, draft[key])
 		)
@@ -728,7 +731,10 @@ const CreatorDecorationEditor = react.memo(({
 						max: 360,
 						value: draft.gradientAngle,
 						disabled: pending,
-						onChange: (event) => setDraft((current) => ({ ...current, gradientAngle: Number(event.currentTarget.value) }))
+						onChange: (event) => {
+							const nextAngle = Number(event.currentTarget.value);
+							setDraft((current) => ({ ...current, gradientAngle: nextAngle }));
+						}
 					})
 				)
 			)


### PR DESCRIPTION
Fixes PC creator decoration controls crashing when color or gradient-angle inputs change. DOM values are captured before React functional state updates, with a release-gated regression test.\n\nChecks:\n- Node syntax check\n- 11 focused PC tests\n- git diff --check