### PR TITLE
Use embedded creator decorations

### DIFF
--- a/.github/scripts/creator-decoration-inputs.test.cjs
+++ b/.github/scripts/creator-decoration-inputs.test.cjs
@@ -4,6 +4,7 @@ const { resolve } = require('node:path');
 const test = require('node:test');
 
 const pagesSource = readFileSync(resolve(__dirname, '..', '..', 'Pages.js'), 'utf8');
+const utilsSource = readFileSync(resolve(__dirname, '..', '..', 'Utils.js'), 'utf8');
 
 function getDecorationEditorSource() {
   const start = pagesSource.indexOf('const CreatorDecorationEditor');
@@ -25,4 +26,21 @@ test('creator decoration inputs snapshot DOM values before functional state upda
     /setDraft\(\(current\) => \([^)]*event\.currentTarget/s,
     'React event objects must not be read from deferred state updater callbacks'
   );
+});
+
+test('creator decorations come from sync contributors without an extra Worker request', () => {
+  assert.match(
+    pagesSource,
+    /decoration: !identityHidden && contributor\.decoration/,
+    'sync contributor decorations must survive display normalization'
+  );
+  assert.match(
+    pagesSource,
+    /decoration: contributor\?\.decoration \|\| null/,
+    'support presentation must use the embedded contributor decoration'
+  );
+  assert.doesNotMatch(pagesSource, /fetchCreatorDecorations/);
+  assert.doesNotMatch(utilsSource, /creator-decorations/);
+  assert.match(utilsSource, /discord\.ivl\.is\/v1\/user/);
+  assert.match(utilsSource, /expiresAt: now \+ 60 \* 60 \* 1000/);
 });

--- a/Pages.js
+++ b/Pages.js
@@ -170,7 +170,10 @@ function normalizeContributorEntry(contributor, options = {}) {
 		profileAvailable: !identityHidden && (contributor.profileAvailable ?? !!userHash),
 		anonymous: isAnonymous,
 		isPrivate,
-		identityRedacted
+		identityRedacted,
+		decoration: !identityHidden && contributor.decoration && typeof contributor.decoration === "object"
+			? contributor.decoration
+			: null
 	};
 }
 
@@ -1380,7 +1383,9 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 		[contributors, copy.anonymous]
 	);
 	const visibleContributorSignature = useMemo(
-		() => visibleContributors.map((contributor) => contributor.userHash || contributor.key).join("|"),
+		() => visibleContributors.map((contributor) => (
+			`${contributor.userHash || contributor.key}:${contributor.decoration?.updatedAt || 0}`
+		)).join("|"),
 		[visibleContributors]
 	);
 	const [activeContributor, setActiveContributor] = useState(null);
@@ -1404,22 +1409,20 @@ const CreditFooter = react.memo(({ provider, contributors }) => {
 		if (!discordIds.length) return undefined;
 
 		let cancelled = false;
-		Promise.all([
-			Utils.fetchCreatorDecorations(discordIds).catch(() => ({})),
-			Promise.all(discordIds.map(async (userHash) => {
+		Promise.all(discordIds.map(async (userHash) => {
 				try {
 					return [userHash, await Utils.fetchDiscordSupportTier(userHash)];
 				} catch (error) {
 					console.warn("[ivLyrics] Failed to load supporter role:", error);
 					return [userHash, "none"];
 				}
-			}))
-		]).then(([decorations, tiers]) => {
+			})).then((tiers) => {
 			if (cancelled) return;
 			setSupportByUserHash((current) => {
 				const next = { ...current };
 				for (const [userHash, tier] of tiers) {
-					next[userHash] = { tier, decoration: decorations[userHash] || null };
+					const contributor = visibleContributors.find((item) => item.userHash === userHash);
+					next[userHash] = { tier, decoration: contributor?.decoration || null };
 				}
 				return next;
 			});

--- a/Utils.js
+++ b/Utils.js
@@ -2222,24 +2222,6 @@ const Utils = {
     }
   },
 
-  async fetchCreatorDecorations(userHashes) {
-    const normalized = [...new Set((Array.isArray(userHashes) ? userHashes : [])
-      .map((value) => String(value || "").trim())
-      .filter((value) => this.isDiscordUserHash(value)))].slice(0, 10);
-    if (!normalized.length) return {};
-
-    const params = new URLSearchParams({ userHashes: normalized.join(",") });
-    const response = await fetch(`${this.getAccountApiBase()}/creator-decorations?${params.toString()}`, {
-      cache: "no-store",
-      headers: { Accept: "application/json" },
-    });
-    const body = await response.json();
-    if (!response.ok || !body?.success) {
-      throw new Error(body?.error || "Failed to load creator decoration.");
-    }
-    return Object.fromEntries((body?.data?.items || []).map((item) => [item.userHash, item.decoration]));
-  },
-
   async saveOwnCreatorDecoration(decoration) {
     const response = await fetch(`${this.getAccountApiBase()}/creator-decoration`, {
       method: "PUT",


### PR DESCRIPTION
## What changed

- preserve creator decoration data embedded in sync contributors
- remove the separate public decoration request
- keep Discord supporter role checks on the existing one-hour client cache

## Why

Normal lyric playback should not add a Worker invocation just to render a creator color.

## Validation

- `node --check Pages.js`
- focused PC test suite: 16 passing

